### PR TITLE
Api versioning

### DIFF
--- a/webapi/webapi.py
+++ b/webapi/webapi.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 # webapi.py
 #
 # Copyright (C) 2014 Kano Computing Ltd.


### PR DESCRIPTION
Can has versioned APIs.

The new VersionError that can get thrown can be used to let a user know that they need to update their system as the API Server has changed.
