### PR TITLE
profile: Show specific notifications from kano world

### DIFF
--- a/bin/kano-sync
+++ b/bin/kano-sync
@@ -72,6 +72,25 @@ def do_login():
                 sys.exit(1)
 
 
+def _should_display_notifications(profile):
+    NOTIFY_INTERVAL = 60*60*12 # 12 hours in seconds
+    return 'last_notifications_prompt' not in profile or \
+           (time.time() - int(profile['last_notifications_prompt'])) > NOTIFY_INTERVAL
+
+def _any_notifications_available(profile):
+    return ('notifications' in profile and
+            type(profile['notifications']) is list and
+            len(profile['notifications']) > 0)
+
+# TODO: This should be moved to kano-toolset in the future
+def kano_display_notification(notification):
+    notification_pipe = os.path.join(os.path.expanduser('~'),
+                                     '.kano-notifications.fifo')
+
+    with open(notification_pipe, 'w') as fifo:
+            logger.debug('Pushing {} to the notifications widget'.format(notification))
+            fifo.write(notification + '\n')
+
 def do_sync():
     logger.debug('do_sync')
 
@@ -85,17 +104,10 @@ def do_sync():
     # Push notifications
     try:
         profile = load_profile()
-        if 'last_notifications_prompt' not in profile or \
-           (time.time() - int(profile['last_notifications_prompt'])) > 60*60*24:
-            if 'notifications' in profile and \
-               type(profile['notifications']) is list and \
-               len(profile['notifications']) > 0:
-                with open(os.path.join(os.path.expanduser('~'), '.kano-notifications.fifo'), 'w') as fifo:
-                    fifo.write('world_notification:{}\n'.format(len(profile['notifications'])))
-                    for n in profile['notifications']:
-                        payload = json.dumps(n)
-                        logger.debug('Pushing {} to the notifications widget'.format(payload))
-                        fifo.write(payload + '\n')
+        if _should_display_notifications(profile):
+            if _any_notifications_available(profile):
+                for n in profile['notifications']:
+                    kano_display_notification(json.dumps(n))
 
                 profile['last_notifications_prompt'] = int(time.time())
                 save_profile(profile)

--- a/kano_world/session.py
+++ b/kano_world/session.py
@@ -265,12 +265,7 @@ class KanoWorldSession(object):
 
             for entry in data['entries']:
                 if entry['read'] is False:
-                    n = {
-                        'title': 'Kano World',
-                        'byline': entry['title'],
-                        'image': None,
-                        'command': None
-                    }
+                    n = self._process_notification(entry)
                     notifications.append(n)
 
             try:
@@ -282,3 +277,34 @@ class KanoWorldSession(object):
         profile['notifications'] = notifications
         save_profile(profile)
         return True, None
+
+    def _process_notification(self, entry):
+        """ Cherry picks information from a Kano World notification
+            based on its type and returns it in a dict.
+
+            :param entry: A notification entry from the World API
+            :returns: A dict that can be passed to the notification widget
+        """
+
+        MINECRAFT_SHARE_IMG = '/usr/share/kano-profile/media/images/environments/280x170/all/minecraft_levelup.png'
+        PONG_SHARE_IMG = '/usr/share/kano-profile/media/images/environments/280x170/all/arcade_hall_levelup.png'
+
+        n = {
+            'title': 'Kano World',
+            'byline': entry['title'],
+            'image': None,
+            'command': 'kano-world-launcher'
+        }
+
+        # Customise settings for known types
+        if entry['category'] == 'follows':
+            n['title'] = 'New follower!'
+        elif entry['category'] == 'share-items':
+            n['title'] = 'New share!'
+
+            if entry['type'] == 'make-minecraft':
+                n['image'] = MINECRAFT_SHARE_IMG
+            elif entry['type'] == 'make-pong':
+                n['image'] = PONG_SHARE_IMG
+
+        return n


### PR DESCRIPTION
kano-sync will now display all the unread notifications from kano world
one by one instead of just the summary.

TODO: We need to filter them for now because they are not yet finalised.

I also added a delay of one day, so these will be shown at most once a day. Maybe shorter would be better.

Related to https://github.com/KanoComputing/peldins/issues/1373

cc @skarbat @alex5imon 
