### PR TITLE
Removing unlocker-related code

### DIFF
--- a/bin/kano-profile-cli
+++ b/bin/kano-profile-cli
@@ -14,7 +14,7 @@ if __name__ == '__main__' and __package__ is None:
         sys.path.insert(1, dir_path)
 
 from kano_profile.apps import get_app_data_dir, load_app_state_variable
-from kano_profile.profile import set_unlocked, load_profile, get_avatar, get_environment
+from kano_profile.profile import load_profile, get_avatar, get_environment
 from kano_profile.badges import save_app_state_variable_with_dialog, calculate_xp, \
     calculate_kano_level, increment_app_state_variable_with_dialog
 from kano_world.functions import is_registered, get_mixed_username, has_token
@@ -36,7 +36,7 @@ if len(sys.argv) == 1:
     help = 'Wrong usage, needs an argument\n'
     help += 'Possible uses: get_app_data_dir, load_app_state_variable, save_app_state_variable\n'
     help += 'save_app_state_variable_get_xp_diff, increment_app_state_variable\n'
-    help += 'unlock, lock, is_registered, get_stats, get_email, get_notifications,\n'
+    help += 'is_registered, get_stats, get_email, get_notifications,\n'
     help += 'get_notifications_count, increment_app_runtime'
     sys.exit(help)
 
@@ -90,14 +90,6 @@ elif sys.argv[1] == 'increment_app_state_variable':
     elif is_number(value):
         value = float(value)
     increment_app_state_variable_with_dialog(app_name, variable, value)
-
-elif sys.argv[1] == 'unlock':
-    check_arg_len(1)
-    set_unlocked(True)
-
-elif sys.argv[1] == 'lock':
-    check_arg_len(1)
-    set_unlocked(False)
 
 elif sys.argv[1] == 'is_registered':
     check_arg_len(1)

--- a/kano_profile/apps.py
+++ b/kano_profile/apps.py
@@ -12,7 +12,6 @@ from kano.utils import read_json, write_json, get_date_now, ensure_dir, chown_pa
     run_print_output_error, is_running, run_bg
 from kano.logging import logger
 from .paths import apps_dir, xp_file, kanoprofile_dir, app_profiles_file
-from .profile import is_unlocked
 
 
 def get_app_dir(app_name):
@@ -42,20 +41,12 @@ def load_app_state(app_name):
 
 def load_app_state_variable(app_name, variable):
     data = load_app_state(app_name)
-    if is_unlocked():
-        data['level'] = 999
     if variable in data:
         return data[variable]
 
 
 def save_app_state(app_name, data):
     logger.debug('save_app_state {}'.format(app_name))
-
-    if is_unlocked():
-        try:
-            data['level'] = load_app_state(app_name)['level']
-        except Exception:
-            pass
 
     app_state_file = get_app_state_file(app_name)
     data['save_date'] = get_date_now()
@@ -76,8 +67,6 @@ def save_app_state(app_name, data):
 def save_app_state_variable(app_name, variable, value):
     logger.debug('save_app_state_variable {} {} {}'.format(app_name, variable, value))
 
-    if is_unlocked() and variable == 'level':
-        return
     data = load_app_state(app_name)
     data[variable] = value
 
@@ -87,8 +76,6 @@ def save_app_state_variable(app_name, variable, value):
 def increment_app_state_variable(app_name, variable, value):
     logger.debug('increment_app_state_variable {} {} {}'.format(app_name, variable, value))
 
-    if is_unlocked() and variable == 'level':
-        return
     data = load_app_state(app_name)
     if variable not in data:
         data[variable] = 0

--- a/kano_profile/badges.py
+++ b/kano_profile/badges.py
@@ -14,7 +14,6 @@ from kano.logging import logger
 from kano.utils import read_json, is_gui, run_bg, run_cmd, is_running
 from .paths import xp_file, levels_file, rules_dir, bin_dir, app_profiles_file
 from .apps import load_app_state, get_app_list, save_app_state
-from .profile import is_unlocked
 
 
 def calculate_xp():
@@ -259,8 +258,6 @@ def save_app_state_with_dialog(app_name, data):
 def save_app_state_variable_with_dialog(app_name, variable, value):
     logger.debug('save_app_state_variable_with_dialog {} {} {}'.format(app_name, variable, value))
 
-    if is_unlocked() and variable == 'level':
-        return
     data = load_app_state(app_name)
     data[variable] = value
 
@@ -270,8 +267,6 @@ def save_app_state_variable_with_dialog(app_name, variable, value):
 def increment_app_state_variable_with_dialog(app_name, variable, value):
     logger.debug('increment_app_state_variable_with_dialog {} {} {}'.format(app_name, variable, value))
 
-    if is_unlocked() and variable == 'level':
-        return
     data = load_app_state(app_name)
     if variable not in data:
         data[variable] = 0

--- a/kano_profile/profile.py
+++ b/kano_profile/profile.py
@@ -47,22 +47,6 @@ def save_profile_variable(variable, value):
     save_profile(profile)
 
 
-def set_unlocked(boolean):
-    logger.debug('set_unlocked {}'.format(boolean))
-
-    profile = load_profile()
-    profile['unlocked'] = boolean
-    save_profile(profile)
-
-
-def is_unlocked():
-    profile = load_profile()
-    if 'unlocked' in profile:
-        return load_profile()['unlocked']
-    else:
-        return False
-
-
 def get_avatar():
     profile = load_profile()
     if 'avatar' in profile:


### PR DESCRIPTION
This should remove all references to kano-unlocker. This functionality of profile was only used [from here](https://github.com/KanoComputing/kanux-utils/blob/kano-unlocker/bin/kano-unlocker#L39) -- I grepped for that through all our code.

https://github.com/KanoComputing/peldins/issues/1372

cc @alex5imon 
