### PR TITLE
profile-gui: Will now show online badges

### DIFF
--- a/bin/kano-sync
+++ b/bin/kano-sync
@@ -102,8 +102,9 @@ def do_sync():
                     image = n["image"] if "image" in n else None
                     command = n["command"] if "command" in n else None
                     sound = n["sound"] if "sound" in n else None
-                    display_generic_notification(n["title"], n["byline"], image,
-                                                 command, sound, "world")
+                    display_generic_notification(n["title"], n["byline"],
+                                                 image, command, sound,
+                                                 "world")
 
                 profile['last_notifications_prompt'] = int(time.time())
                 save_profile(profile)

--- a/kano_profile/badges.py
+++ b/kano_profile/badges.py
@@ -9,10 +9,12 @@
 from __future__ import division
 
 import os
+import json
 
 from kano.logging import logger
-from kano.utils import read_json, is_gui, run_bg, run_cmd, is_running
-from .paths import xp_file, levels_file, rules_dir, bin_dir, app_profiles_file
+from kano.utils import read_json, is_gui, run_bg
+from .paths import xp_file, levels_file, rules_dir, bin_dir, \
+    app_profiles_file, online_badges_dir, online_badges_file
 from .apps import load_app_state, get_app_list, save_app_state
 
 
@@ -212,6 +214,16 @@ def compare_badges_dict(old, new):
                     pass
     return changes
 
+
+def load_online_badges():
+    if not os.path.isdir(online_badges_dir):
+        return {}
+
+    online_badges = {}
+    with open(online_badges_file, "r") as f:
+        online_badges = json.load(f)
+
+    return online_badges
 
 def save_app_state_with_dialog(app_name, data):
     logger.debug('save_app_state_with_dialog {}'.format(app_name))

--- a/kano_profile/paths.py
+++ b/kano_profile/paths.py
@@ -58,6 +58,9 @@ profile_dir = os.path.join(kanoprofile_dir, profile_dir_str)
 apps_dir_str = 'apps'
 apps_dir = os.path.join(kanoprofile_dir, apps_dir_str)
 
+online_badges_dir = os.path.join(profile_dir, "badges")
+online_badges_file = os.path.join(online_badges_dir, "badges.json")
+
 profile_file_str = 'profile.json'
 profile_file = os.path.join(profile_dir, profile_file_str)
 

--- a/kano_profile_gui/images.py
+++ b/kano_profile_gui/images.py
@@ -10,10 +10,16 @@ import os
 
 from kano.logging import logger
 from .paths import image_dir
+from kano_profile.paths import online_badges_dir
 
 
 # "Badge", folder_name, file_name, width of image
 def get_image(category, subcategory, name, subfolder_str):
+    # The online badge image files are stored in the home directory.
+    # The function bellow gets the corrects path.
+    if category == "badges" and subcategory == "online":
+        return get_online_badge_path(name)
+
     folder = os.path.join(image_dir, category, subfolder_str, subcategory)
     filename = '{name}.png'.format(name=name)
     fullpath = os.path.join(folder, filename)
@@ -35,3 +41,5 @@ def get_image(category, subcategory, name, subfolder_str):
     return fullpath
 
 
+def get_online_badge_path(name):
+    return os.path.join(online_badges_dir, "{}.png".format(name))

--- a/kano_profile_gui/selection_table_components/info_screen_ui.py
+++ b/kano_profile_gui/selection_table_components/info_screen_ui.py
@@ -7,7 +7,7 @@
 #
 # If an environment/avatar/badge is selected, we go to this screen to show more info
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GdkPixbuf
 import kano_profile_gui.selection_table_components.info_text_ui as info_text
 import kano_profile_gui.components.icons as icons
 import kano_profile_gui.components.cursor as cursor
@@ -176,7 +176,10 @@ class InfoScreenUi():
 
     def get_image_at_size(self):
         filename = self.get_filename_at_size()
-        self.image.set_from_file(filename)
+
+        pb = GdkPixbuf.Pixbuf.new_from_file_at_size(filename, self.width,
+                                                    self.height)
+        self.image.set_from_pixbuf(pb)
 
     def get_filename_at_size(self):
         return self.get_visible_item().get_filename_at_size(self.width, self.height)

--- a/kano_profile_gui/selection_table_components/item_ui.py
+++ b/kano_profile_gui/selection_table_components/item_ui.py
@@ -9,7 +9,7 @@
 # Used for badges, environments and avatar screen
 
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GdkPixbuf
 import kano_profile_gui.components.icons as icons
 import kano_profile_gui.components.cursor as cursor
 
@@ -47,7 +47,15 @@ class ItemUi():
         self.fixed = Gtk.Fixed()
         self.fixed.set_size_request(self.width, self.height)
         self.fixed.put(self.hover_box, 0, self.height - self.label_height)
-        self.fixed.put(self.image, 0, 0)
+
+        # The image can be smaller than the square in which case we
+        # center it in the view.
+        pb = self.image.get_pixbuf()
+        img_width = pb.get_width()
+        img_height = pb.get_height()
+        self.fixed.put(self.image, (self.width - img_width) / 2,
+                        (self.height - img_height) / 2)
+
         self.fixed.put(self.locked_fixed, 0, 0)
 
         self.button.add(self.fixed)
@@ -104,7 +112,10 @@ class ItemUi():
 
     def get_image_at_size(self):
         filename = self.get_filename_at_size(self.width, self.height)
-        self.image.set_from_file(filename)
+
+        pb = GdkPixbuf.Pixbuf.new_from_file_at_size(filename, self.width,
+                                                    self.height)
+        self.image.set_from_pixbuf(pb)
 
     def get_title(self):
         return self.item.title.upper()

--- a/kano_profile_gui/selection_table_components/table_ui.py
+++ b/kano_profile_gui/selection_table_components/table_ui.py
@@ -12,7 +12,7 @@ from gi.repository import Gtk
 import kano_profile_gui.selection_table_components.item_ui as item_ui
 import kano_profile_gui.selection_table_components.item_group as item_group
 from kano_profile_gui.selection_table_components import item_info
-from kano_profile.badges import calculate_badges
+from kano_profile.badges import calculate_badges, load_online_badges
 import math
 #from .images import get_image
 
@@ -27,6 +27,10 @@ class TableUi():
         item_array = []
         number_of_badges = 0
         category_dict = calculate_badges()[category_name]
+
+        # Load the badges from the home directory
+        if category_name == "badges":
+            category_dict["online"] = load_online_badges()
 
         # To access video dude jason:
         # calculate_badges()['avatars']['video_dude']

--- a/kano_world/functions.py
+++ b/kano_world/functions.py
@@ -127,6 +127,10 @@ def sync():
     if not success:
         return False, value
 
+    success, value = glob_session.download_online_badges()
+    if not success:
+        return False, value
+
     return True, None
 
 


### PR DESCRIPTION
kano-sync will download any kano-world awarded badges to

```
~/.kanoprofile/badges/
```

kano-profile-gui will then look there when displaying the badges and
show them.

Related to: https://github.com/KanoComputing/peldins/issues/1507

cc @alex5imon @carolineclark 
