### PR TITLE
Add loading of XP gain directly from file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-profile (1.3-4) unstable; urgency=low
+
+  * Adding ability to load XP gain for challenges from file
+
+ -- Team Kano <dev@kano.me>  Wed, 17 Dec 2014 18:09:00 +0000
+
 kano-profile (1.3-3) unstable; urgency=low
 
   * Adding XP configuration for the linux-story

--- a/kano_profile/apps.py
+++ b/kano_profile/apps.py
@@ -112,3 +112,11 @@ def launch_project(app, filename, data_dir):
     cmd = app_profiles[app]['cmd'].format(fullpath=fullpath, filename=filename)
     _,_,rc=run_print_output_error(cmd)
     return rc
+
+def get_app_xp_for_challenge(app, challenge_no):
+    xp_file_json = read_json(xp_file)
+
+    try:
+        return xp_file_json[app]['level'][challenge_no]
+    except KeyError:
+        return 0


### PR DESCRIPTION
The original method to finding the XP gain whenever a challenge was
completed was to calculate the XP, save the challenge change and
calculate the XP again (and compare the two). This commit allows reading
the XP gain directly from the file used to calculate the XP.

cc @pazdera
