### PR TITLE
Fix KeyError when removing sensitive data from server request

### DIFF
--- a/kano_world/connection.py
+++ b/kano_world/connection.py
@@ -22,9 +22,16 @@ except Exception:
 
 
 def _remove_sensitive_data(request_debug):
-    if request_debug and 'data' in request_debug and \
-       request_debug['data'] and 'password' in request_debug['data']:
-        request_debug['data']['password'] = 'removed'
+    if request_debug \
+        and 'data' in request_debug \
+        and request_debug['data']:
+
+        import ast
+        data = ast.literal_eval(request_debug['data'])
+
+        if 'password' in data:
+            data['password'] = 'removed'
+            request_debug['data'] = data
 
     return request_debug
 


### PR DESCRIPTION
KanoComputing/peldins#1563
The server response gets logged on registration failure but this
includes the password which we strip out. The current implementation
assumes that the data from the server request is a dictionary, but it is
just a string so needs to be parsed as a dict before use.
