### PR TITLE
Add secondary email to register function

### DIFF
--- a/kano_world/functions.py
+++ b/kano_world/functions.py
@@ -73,6 +73,8 @@ def login_register_data(data):
     # However we only need to store it if it has a meaningful value
     if data['session']['user']['secondary_email']:
         profile['secondary_email'] = data['session']['user']['secondary_email']
+    else:
+        profile.pop('secondary_email', None)
     save_profile(profile)
     try:
         glob_session = KanoWorldSession(profile['token'])


### PR DESCRIPTION
This Change adds the option to use a secondary email when registering for a kano world account. Furthermore, it adds the `get_secondary_email()` function similar to `get_email()`.
Additionally, it adds the secondary_email to the profile structure json in case we need to use it somewhere.
