### PR TITLE
Recreate the character when necessary after sync

### DIFF
--- a/kano_profile/profile.py
+++ b/kano_profile/profile.py
@@ -119,6 +119,13 @@ def get_avatar_circ_image_path():
 
 
 def set_avatar(subcat, item, sync=False):
+    """ Set the avatar in the local profile structure and optionally sync
+    :param subcat: first field to be used (usually character namespace)
+    :param item: Dict with the mapping from category to item
+    :param sync: (Optional) sync to World
+    :returns: True iff an update has happenned internally, False iff the
+              internal structures were up to date
+    """
     profile = load_profile()
     if 'version' in profile and profile['version'] == 2:
         if type(item) != dict:
@@ -139,8 +146,8 @@ def set_avatar(subcat, item, sync=False):
         profile['avatar'] = [subcat, item]
         if sync:
             sync_profile()
-        recreate_char(block=sync)
         save_profile(profile)
+    return needs_update
 
 
 def get_environment():
@@ -153,6 +160,12 @@ def get_environment():
 
 
 def set_environment(environment, sync=False):
+    """ Set the avatar in the local profile structure and optionally sync
+    :param environment: Environment name to be used
+    :param sync: (Optional) sync to World
+    :returns: True iff an update has happenned internally, False iff the
+              internal structures were up to date
+    """
     profile = load_profile()
     needs_update = True
     if 'environment' in profile:
@@ -163,8 +176,8 @@ def set_environment(environment, sync=False):
         profile['environment'] = environment
         if sync:
             sync_profile()
-        recreate_char(block=sync)
         save_profile(profile)
+    return needs_update
 
 
 def sync_profile():

--- a/kano_world/session.py
+++ b/kano_world/session.py
@@ -13,7 +13,8 @@ import os
 from kano.logging import logger
 from kano.utils import download_url, read_json, ensure_dir
 from kano_profile.profile import (load_profile, set_avatar, set_environment,
-                                  save_profile, save_profile_variable)
+                                  save_profile, save_profile_variable,
+                                  recreate_char)
 from kano_profile.badges import calculate_xp
 from kano_profile.apps import get_app_list, load_app_state, save_app_state
 from kano_profile.paths import app_profiles_file, online_badges_dir, \
@@ -199,19 +200,24 @@ class KanoWorldSession(object):
                 return False, text
 
         try:
-            vesion_no = data['user']['avatar']['generator']['version']
+            version_no = data['user']['avatar']['generator']['version']
             save_profile_variable('version', version_no)
         except Exception:
             pass
 
+        updated_locally = False
         try:
             avatar_subcat, avatar_item = data['user']['avatar']['generator']['character']
-            set_avatar(avatar_subcat, avatar_item)
+            updated_locally = set_avatar(avatar_subcat, avatar_item)
 
             environment = data['user']['avatar']['generator']['environment'][1]
-            set_environment(environment)
+            updated_locally |= set_environment(environment)
+
         except Exception:
             pass
+
+        if updated_locally:
+            recreate_char(block=True)
 
         # app states
         try:


### PR DESCRIPTION
Only try to recreate the assets once it is necessary. This should fix an issue where the background was synced to the previous value before the asset is set
