### PR TITLE
Handle failed open files with grace

### DIFF
--- a/kano_world/session.py
+++ b/kano_world/session.py
@@ -11,7 +11,7 @@ import json
 import os
 
 from kano.logging import logger
-from kano.utils import download_url, read_json, ensure_dir, chown_path
+from kano.utils import download_url, read_json, ensure_dir
 from kano_profile.profile import (load_profile, set_avatar, set_environment,
                                   save_profile, save_profile_variable,
                                   recreate_char)


### PR DESCRIPTION
This is not supposed to solve the issue of files not having the right owner or permissions,
rather to allow us to deal with such cases. It will also allow for more precise logging in case
of error.
