### PR TITLE
Disabling python requests warning about SSL

### DIFF
--- a/kano_world/connection.py
+++ b/kano_world/connection.py
@@ -7,6 +7,10 @@
 #
 
 import requests
+
+# TODO: Remove this statement after upgrading to a friendly Python-requests match
+requests.packages.urllib3.disable_warnings()
+
 from kano.logging import logger
 from kano_world.config import API_URL
 from pprint import pformat

--- a/kano_world/session.py
+++ b/kano_world/session.py
@@ -7,6 +7,10 @@
 #
 
 import requests
+
+# TODO: Remove this statement after upgrading to a friendly Python-requests match
+requests.packages.urllib3.disable_warnings()
+
 import json
 import os
 

--- a/tools/activate_account.py
+++ b/tools/activate_account.py
@@ -11,6 +11,9 @@ import sys
 import os
 import requests
 
+# TODO: Remove this statement after upgrading to a friendly Python-requests match
+requests.packages.urllib3.disable_warnings()
+
 if __name__ == '__main__' and __package__ is None:
     dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     if dir_path != '/usr':


### PR DESCRIPTION
- Latest versions of requests raise a warning with our current
  python version, the functionality works well, so we are
  disabling the annoying messages for the time being
