### PR TITLE
Tracker permission

### DIFF
--- a/kano_profile/tracker.py
+++ b/kano_profile/tracker.py
@@ -29,20 +29,13 @@ from kano_profile.paths import tracker_dir, tracker_events_file, \
     tracker_token_file
 
 
-class open_locked:
+class open_locked(file):
     """ A version of open with an exclusive lock to be used within
         controlled execution statements.
     """
-
-    def __init__(self, path, mode):
-        self._fd = open(path, mode)
-        fcntl.flock(self._fd, fcntl.LOCK_EX)
-
-    def __enter__(self):
-        return self._fd
-
-    def __exit__(self, exit_type, value, traceback):
-        self._fd.close()
+    def __init__(self, *args, **kwargs):
+        super(open_locked, self).__init__(*args, **kwargs)
+        fcntl.flock(self, fcntl.LOCK_EX)
 
 
 def load_token():


### PR DESCRIPTION
This change adds better handling for file access errors in the tracker. Furthermore it ensures that the right owner is set for the files so that even where it is ran as sudo the logs will be writeable from the user.
