### PR TITLE
Login: Fix broken and undefined calls in the First Screen

### DIFF
--- a/kano_login/first_screen.py
+++ b/kano_login/first_screen.py
@@ -102,7 +102,7 @@ class FirstScreen(FirstScreenTemplate):
 
     def repack(self):
         self.win.remove_main_widget()
-        self.win.set_main_widget(self.template)
+        self.win.set_main_widget(self)
 
 
 class NoInternet(Template):
@@ -121,10 +121,10 @@ class NoInternet(Template):
         kano_button_label = "CONNECT"
         orange_button_label = "Register later"
 
-        Template.__init__(self, header, subheader, image_filename,
+        Template.__init__(self, image_filename, header, subheader,
                           kano_button_label, orange_button_label)
 
-        self.win.set_main_widget(self.template)
+        self.win.set_main_widget(self)
         self.kano_button.connect("button_release_event", self.connect)
 
         # Since cannot pass with keyboard, set it so it cannot receive


### PR DESCRIPTION
Attempts were made to access the `template` member of several of the
classes defined in `first_screen.py` when it should just reference
itself. Also, the call to construct the base class of NoInternet
included parameters in the incorrect order which resulted in peculiar
results.

cc @carolineclark 