### PR TITLE
i18n: Fix redefined '_'

### DIFF
--- a/kano_profile_gui/MenuBar.py
+++ b/kano_profile_gui/MenuBar.py
@@ -131,7 +131,7 @@ class HomeButton(Gtk.Button):
         title_label = Gtk.Label(username, xalign=0)
         title_label.get_style_context().add_class("home_button_name")
 
-        level, progress, _ = calculate_kano_level()
+        level, dummy, dummy = calculate_kano_level()
         level_label = Gtk.Label(_("Level {}").format(level), xalign=0)
         level_label.get_style_context().add_class("home_button_level")
 


### PR DESCRIPTION
When translating strings, they are marked with the `_` function provided
by gettext. This, however, can be overwritten `_` is assigned a value
(as can often be the case by convention when a function output is to be
ignored). Fix this by assigning the unused parameters to a different
variable.