### PR TITLE
Fix errors caused by incorrect character limits

### DIFF
--- a/kano_registration_gui/GetData.py
+++ b/kano_registration_gui/GetData.py
@@ -215,16 +215,9 @@ class GetData3(DataTemplate):
         self.t_and_cs.connect("t-and-cs-clicked",
                               self.show_terms_and_conditions)
 
-        self.marketing_checkbutton = Gtk.CheckButton.new_with_label(
-            _("Email me cool stuff to do with my Kano")
-        )
-        self.marketing_checkbutton.get_style_context().add_class("get_data_checkbutton")
-        self.marketing_checkbutton.set_margin_left(30)
-        marketing_enabled = get_cached_data("marketing_enabled")
 
-        chk_btn_label = self.marketing_checkbutton.get_child()
-        chk_btn_label.set_max_width_chars(20)
-        chk_btn_label.set_line_wrap(True)
+        marketing_container = self._create_marketing_checkbox()
+        marketing_enabled = get_cached_data("marketing_enabled")
 
         if marketing_enabled is not None:
             self.marketing_checkbutton.set_active(marketing_enabled)
@@ -260,10 +253,30 @@ class GetData3(DataTemplate):
         self.entries = [self.email_entry]
 
         box.pack_start(self.t_and_cs, False, False, 10)
-        box.pack_start(self.marketing_checkbutton, False, False, 0)
+        box.pack_start(marketing_container, False, False, 0)
         box.set_margin_top(20)
 
         self.add(box)
+
+
+    def _create_marketing_checkbox(self):
+        self.marketing_checkbutton = Gtk.CheckButton()
+        self.marketing_checkbutton.get_style_context().add_class(
+            "get_data_checkbutton")
+        self.marketing_checkbutton.set_margin_left(30)
+
+        marketing_label = Gtk.Label(_("Email me cool stuff to do with my Kano"))
+        marketing_label.set_max_width_chars(20)
+        marketing_label.set_line_wrap(True)
+
+        marketing_container = Gtk.Box()
+        marketing_container.pack_start(self.marketing_checkbutton,
+                                       False, False, 0)
+        marketing_container.get_style_context().add_class(
+            "get_data_checkbutton")
+        marketing_container.pack_start(marketing_label, False, False, 0)
+
+        return marketing_container
 
     def disable_all(self):
         self.email_entry.set_sensitive(False)

--- a/kano_registration_gui/TermsAndConditions.py
+++ b/kano_registration_gui/TermsAndConditions.py
@@ -26,7 +26,7 @@ class TermsAndConditions(Gtk.Box):
         self.tc_button = OrangeButton(_("I agree to the terms and conditions"))
         self.tc_button.connect("clicked", self._emit_t_and_c_signal)
 
-        tc_label = self.tc_button.get_child()
+        tc_label = self.tc_button.label
         tc_label.set_max_width_chars(20)
         tc_label.set_line_wrap(True)
 

--- a/media/CSS/register.css
+++ b/media/CSS/register.css
@@ -62,9 +62,6 @@ GtkCheckButton:active:insensitive {
     border-width: 2px;
     -GtkCheckButton-indicator-size: 40;
     -GtkCheckButton-indicator-spacing: 3;
-}
-
-.get_data_checkbutton GtkLabel {
     color: #555555;
     font: Bariol 13;
 }


### PR DESCRIPTION
When setting the maximum length of labels for the purposes of allowing
unbroken strings for translation, calls to limit the character length of
labels weren't implemented correctly. Resolve this by accessing the
correct labels.

cc @carolineclark @pazdera 