### PR TITLE
i18n: Use the kano-i18n library for i18n init

### DIFF
--- a/bin/kano-login
+++ b/bin/kano-login
@@ -23,7 +23,6 @@ Options:
 import os
 import sys
 import docopt
-import gettext
 from gi.repository import Gtk, GObject
 
 if __name__ == '__main__' and __package__ is None:
@@ -34,7 +33,8 @@ if __name__ == '__main__' and __package__ is None:
     else:
         LOCALE_PATH = None
 
-gettext.install('kano-tutorial', LOCALE_PATH, unicode=1)
+import kano_i18n.init
+kano_i18n.init.install('kano-tutorial', LOCALE_PATH)
 
 from kano.gtk3.application_window import ApplicationWindow
 from kano.gtk3.apply_styles import apply_styling_to_screen

--- a/bin/kano-profile-gui
+++ b/bin/kano-profile-gui
@@ -8,7 +8,6 @@
 
 import os
 import sys
-import gettext
 from gi.repository import Gtk
 
 if __name__ == '__main__' and __package__ is None:
@@ -19,7 +18,8 @@ if __name__ == '__main__' and __package__ is None:
     else:
         LOCALE_PATH = None
 
-gettext.install('kano-tutorial', LOCALE_PATH, unicode=1)
+import kano_i18n.init
+kano_i18n.init.install('kano-tutorial', LOCALE_PATH)
 
 from kano_profile_gui.character_screens import CharacterDisplay
 from kano_profile_gui.badge_screen import BadgeScreen

--- a/bin/kano-share
+++ b/bin/kano-share
@@ -11,7 +11,6 @@ from gi.repository import Gtk
 import os
 import sys
 import subprocess
-import gettext
 
 if __name__ == '__main__' and __package__ is None:
     DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -21,7 +20,8 @@ if __name__ == '__main__' and __package__ is None:
     else:
         LOCALE_PATH = None
 
-gettext.install('kano-tutorial', LOCALE_PATH, unicode=1)
+import kano_i18n.init
+kano_i18n.init.install('kano-tutorial', LOCALE_PATH)
 
 from kano.network import is_internet
 from kano.utils import read_json

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: kano-profile
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, kano-toolset (>=1.2-2),
          gir1.2-gtk-3.0, libkdesk-dev, kano-widgets (>=1.2.4-3), python-yaml,
-         kano-settings (>=1.3-2), xtoolwait, python-imaging
+         kano-settings (>=1.3-2), xtoolwait, python-imaging, kano-i18n
 Recommends: kano-fonts
 Description: Profile app for KANO
 Provides: kano-share


### PR DESCRIPTION
Instead of each package handling i18n initialisation independently, use
the `kano-i18n` library.

cc @pazdera @convolu 