### PR TITLE
tracker: Adding a subprocess tracker

### DIFF
--- a/bin/kano-tracker-ctl
+++ b/bin/kano-tracker-ctl
@@ -15,6 +15,7 @@ Usage:
   kano-tracker-ctl refresh [-w]
   kano-tracker-ctl session (start|end) <name> <pid>
   kano-tracker-ctl session log <name> <started> <length>
+  kano-tracker-ctl session run <name> <command>
   kano-tracker-ctl (+1|action) <name>
   kano-tracker-ctl data <name> <value>
   kano-tracker-ctl generate <event>
@@ -44,7 +45,8 @@ if __name__ == '__main__' and __package__ is None:
 from kano_profile.paths import tracker_dir, tracker_events_file
 from kano_profile.tracker import open_locked, session_start, session_end, \
     get_session_file_path, track_action, track_data, get_session_event, \
-    session_log, generate_tracker_token, load_token, get_utc_offset
+    session_log, generate_tracker_token, load_token, get_utc_offset, \
+    track_subprocess
 from kano.logging import logger
 from kano.utils import delete_file, ensure_dir, is_running, \
     get_rpi_model, detect_kano_keyboard
@@ -352,12 +354,15 @@ def main():
         clear_sessions()
     elif args['refresh']:
         update_status(args['--watch'])
-    elif args['session'] and args['start']:
-        session_start(args['<name>'], args['<pid>'])
-    elif args['session'] and args['end']:
-        session_end(get_session_file_path(args['<name>'], args['<pid>']))
-    elif args['session'] and args['log']:
-        session_log(args['<name>'], args['<started>'], args['<length>'])
+    elif args['session']:
+        if args['start']:
+            session_start(args['<name>'], args['<pid>'])
+        elif args['end']:
+            session_end(get_session_file_path(args['<name>'], args['<pid>']))
+        elif args['log']:
+            session_log(args['<name>'], args['<started>'], args['<length>'])
+        elif args['run']:
+            track_subprocess(args['<name>'], args['<command>'])
     elif args['+1'] or args['action']:
         track_action(args['<name>'])
     elif args['generate']:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-profile (2.1-1) unstable; urgency=low
+
+  * kano-tracker-ctl: adding subprocess session tracking.
+
+ -- Team Kano <dev@kano.me>  Mon, 22 Jun 2015 16:11:00 +0100
+
 kano-profile (2.0-1) unstable; urgency=low
 
   * Adding kano-registration-gui

--- a/kano_profile/tracker.py
+++ b/kano_profile/tracker.py
@@ -19,6 +19,8 @@ import fcntl
 import json
 import os
 import hashlib
+import subprocess
+import shlex
 
 from kano.utils import get_program_name, is_number, read_file_contents, \
     get_cpu_id, chown_path, ensure_dir
@@ -250,6 +252,24 @@ def track_action(name):
             af.write(json.dumps(event) + "\n")
         if 'SUDO_USER' in os.environ:
             chown_path(tracker_events_file)
+
+
+def track_subprocess(name, cmd):
+    """ Launch and track the session of a process.
+
+        :param name: Name of the session.
+        :type name: str
+
+        :param cmd: The command line (env vars are not supported).
+        :type cmd: str
+    """
+
+    cmd_args = shlex.split(cmd)
+    p = subprocess.Popen(cmd_args)
+    pid = p.pid
+    session_start(name, pid)
+    p.wait()
+    session_end(get_session_file_path(name, pid))
 
 
 def get_action_event(name):


### PR DESCRIPTION
This can be used as a wrapper for tracking the sessions of processes
that we have no control over. Sample usage below:

    kano-tracker session run play-minecraft 'minecraft-pi'
    kano-tracker session run chromium 'chromium'
    kano-tracker session run sleep 'sleep 10'

Related to: https://github.com/KanoComputing/peldins/issues/1910

cc @alex5imon 