### PR TITLE
Login: Fix internet required to login sizing

### DIFF
--- a/kano_login/swag_screen.py
+++ b/kano_login/swag_screen.py
@@ -57,7 +57,6 @@ class SwagScreen(Template):
         self.win.set_main_widget(self)
         self.kano_button.connect("button_release_event", self.next_screen)
         self.kano_button.connect("key_release_event", self.next_screen)
-        self.button_box.set_margin_bottom(30)
         self.kano_button.grab_focus()
         self.win.show_all()
 

--- a/kano_login/templates/template.py
+++ b/kano_login/templates/template.py
@@ -38,6 +38,7 @@ class Template(Gtk.Box):
 
         self.button_box = Gtk.ButtonBox(spacing=10)
         self.button_box.set_layout(Gtk.ButtonBoxStyle.SPREAD)
+        self.button_box.set_margin_bottom(30)
         self.pack_start(self.button_box, False, False, 0)
 
         if not orange_button_text == "":


### PR DESCRIPTION
KanoComputing/peldins#1897
The screen which informs the user that internet is required to continue
logging in had the wrong bottom padding. Add the correct padding to the
template and remove corrections made by instances of the template.

cc @pazdera @convolu 