### PR TITLE
Category Menu scrollbar

### DIFF
--- a/kano_avatar_gui/CategoryMenu.py
+++ b/kano_avatar_gui/CategoryMenu.py
@@ -9,6 +9,7 @@
 from gi.repository import Gtk, GObject
 from kano_avatar_gui.SelectMenu import SelectMenu
 from kano.gtk3.cursor import attach_cursor_events
+from kano.gtk3.scrolled_window import ScrolledWindow
 
 
 class CategoryMenu(SelectMenu):
@@ -33,8 +34,17 @@ class CategoryMenu(SelectMenu):
         self.categories = self._parser.list_available_categories()
         SelectMenu.__init__(self, self.categories, self._signal_name)
 
+        # Add the scrollbar for the category menu
+        sw = ScrolledWindow()
+        sw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        # Set the scrollbar to the left
+        sw.set_placement(Gtk.CornerType.TOP_RIGHT)
+        sw.apply_styling_to_widget()
+        sw.set_size_request(-1, 364)
+        self.add(sw)
+
         self._vertbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        self.add(self._vertbox)
+        sw.add(self._vertbox)
 
         # The menu is one item by 7 items
         self.set_size_request(self.item_width, 7 * self.item_height)

--- a/kano_avatar_gui/Menu.py
+++ b/kano_avatar_gui/Menu.py
@@ -41,8 +41,9 @@ class Menu(Gtk.Fixed):
 
         self.cat_position_x = 0
         self.cat_position_y = 0
+        # Added an offset of 18 px to support the scrollbar category menu
         self.pop_up_pos_x = (self.cat_position_x + self._cat_menu.item_width +
-                             5 + 20)
+                             5 + 18)
         self.pop_up_pos_y = self.cat_position_y
         self.put(self._cat_menu, 0, 0)
 

--- a/kano_avatar_gui/Menu.py
+++ b/kano_avatar_gui/Menu.py
@@ -41,7 +41,8 @@ class Menu(Gtk.Fixed):
 
         self.cat_position_x = 0
         self.cat_position_y = 0
-        self.pop_up_pos_x = self.cat_position_x + self._cat_menu.item_width + 5
+        self.pop_up_pos_x = (self.cat_position_x + self._cat_menu.item_width +
+                             5 + 20)
         self.pop_up_pos_y = self.cat_position_y
         self.put(self._cat_menu, 0, 0)
 


### PR DESCRIPTION
Add a vertical scrollbar to the left of the category menu in the avatar gui and registration screen. The scrollbar should only appear only if the number of categories (including the character and environment) exceeds 7.