### PR TITLE
Use Category Display name in the Pop up header

### DIFF
--- a/kano_avatar/conf_parser.py
+++ b/kano_avatar/conf_parser.py
@@ -303,6 +303,16 @@ class AvatarConfParser(object):
             ret = char.category(category_name).get_active_icon()
         return ret
 
+    def get_category_display_name(self, character, category_name):
+        ret = ''
+        char = self.layer(character)
+        if not char:
+            logger.error(("Character '{}' isn't availabble in '{}', can't "
+                          "return display_name").format(character, self))
+        else:
+            ret = char.category(category_name).name()
+        return ret
+
     def get_selected_border(self, character, category_name):
         """ Provides the filename of the selected border of the preview icon
         :param category_name: Category name as a string

--- a/kano_avatar/logic.py
+++ b/kano_avatar/logic.py
@@ -97,6 +97,11 @@ class AvatarCreator(AvatarConfParser):
         return super(AvatarCreator, self).is_unlocked(
             self._sel_char.get_id(), obj_name)
 
+    @has_selected_char("can't return display name")
+    def get_category_display_name(self, cat_id):
+        return super(AvatarCreator, self).get_category_display_name(
+            self._sel_char.get_id(), cat_id)
+
     def char_select(self, char_name):
         """ Set a character as a base
         :param char_name: Character name

--- a/kano_avatar_gui/PopUpItemMenu.py
+++ b/kano_avatar_gui/PopUpItemMenu.py
@@ -71,7 +71,8 @@ class PopUpItemMenu(SelectMenu):
     def _create_top_bar(self):
         top_bar = Gtk.EventBox()
         top_bar.get_style_context().add_class("pop_up_menu_top_bar")
-        label = Gtk.Label(self._category.title())
+        label_txt = self._parser.get_category_display_name(self._category)
+        label = Gtk.Label(label_txt.title())
         label.set_alignment(0, 0.5)
         label.set_margin_left(20)
         top_bar.add(label)


### PR DESCRIPTION
This change reverts the labels of the categories to display the 'display_name' of each category and not its unique id which is meant for internal use