### PR TITLE
Adjust the minimum width of popup menu

### DIFF
--- a/kano_avatar_gui/PopUpItemMenu.py
+++ b/kano_avatar_gui/PopUpItemMenu.py
@@ -55,7 +55,7 @@ class PopUpItemMenu(SelectMenu):
         sw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         sw.apply_styling_to_widget()
         sw.add(self._grid)
-        sw.set_size_request(-1, 294)
+        sw.set_size_request(152, 294)
 
         # Labels the category
         top_bar = self._create_top_bar()


### PR DESCRIPTION
Adjust the width of the popup menu to look uniform even if only one item is present in a category (as it happens with the 'characters' category)