### PR TITLE
After a character change, show the character category

### DIFF
--- a/kano_avatar_gui/Menu.py
+++ b/kano_avatar_gui/Menu.py
@@ -80,6 +80,10 @@ class Menu(Gtk.Fixed):
         self._parser.char_select(char_id)
         self._cat_menu.set_new_categories()
         self._initialise_pop_up_menus()
+        for cat in self.menus:
+            if cat != self._parser.char_label:
+                self.menus[cat]["pop_up"].hide()
+        self.menus[self._parser.char_label]["pop_up"].show()
         self._cat_menu.show_all()
         if randomise:
             self.emit('randomise_all')


### PR DESCRIPTION
This PR fixes an issue where after a new character has been selected, the the Environments PopUpMenu is shown rather than the Characters