### PR TITLE
Make sure 'data' events are being dispatched

### DIFF
--- a/kano_profile/tracker.py
+++ b/kano_profile/tracker.py
@@ -214,7 +214,7 @@ def track_data(name, data):
 
     event = {
         "type": "data",
-        "time": time.time(),
+        "time": int(time.time()),
         "timezone_offset": get_utc_offset(),
         "os_version": OS_VERSION,
         "cpu_id": CPU_ID,


### PR DESCRIPTION
This validation bug was causing all the events of type=data be discarded without sending. The events are all generated correctly, but they were not reaching the database.

This should rectify the issue.

cc @alex5imon @neilgibson

Related to: https://github.com/KanoComputing/peldins/issues/1910