### PR TITLE
Disable buttons on edit

### DIFF
--- a/kano_profile_gui/MenuBar.py
+++ b/kano_profile_gui/MenuBar.py
@@ -123,6 +123,25 @@ class MenuBar(Gtk.EventBox):
     def close_window(self, button):
         Gtk.main_quit()
 
+    def disable_buttons(self):
+        """ Disable all the buttons except for the exit button.
+        The latter's sensitivity is not altered
+        """
+        self._set_button_sensitivity(False)
+
+    def enable_buttons(self):
+        """ Disable all the buttons except for the exit button.
+        The latter's sensitivity is not altered
+        """
+        self._set_button_sensitivity(True)
+
+    def _set_button_sensitivity(self, sensitivity_value):
+        """ Keep all the buttons whose sensitivity we want to control here
+        """
+        self.home_button.set_sensitive(sensitivity_value)
+        for button in self.buttons.itervalues():
+            button["button"].set_sensitive(sensitivity_value)
+
 
 class HomeButton(Gtk.Button):
 

--- a/kano_profile_gui/MenuBar.py
+++ b/kano_profile_gui/MenuBar.py
@@ -130,8 +130,8 @@ class MenuBar(Gtk.EventBox):
         self._set_button_sensitivity(False)
 
     def enable_buttons(self):
-        """ Disable all the buttons except for the exit button.
-        The latter's sensitivity is not altered
+        """ Enable all the menu buttons. The exit button's sensitivity is
+        not altered
         """
         self._set_button_sensitivity(True)
 

--- a/kano_profile_gui/character_screens.py
+++ b/kano_profile_gui/character_screens.py
@@ -86,6 +86,7 @@ class CharacterDisplay(Gtk.EventBox):
     def go_to_edit_character_screen(self, widget=None):
         self._win.empty_main_content()
         self._win.empty_bottom_bar()
+        self._win.menu_bar.disable_buttons()
         CharacterEdit(self._win, self._char_creator)
 
 
@@ -137,4 +138,5 @@ class CharacterEdit(Gtk.EventBox):
         '''
         self._win.empty_main_content()
         self._win.empty_bottom_bar()
+        self._win.menu_bar.enable_buttons()
         CharacterDisplay(self._win)

--- a/media/CSS/kano_profile_gui.css
+++ b/media/CSS/kano_profile_gui.css
@@ -23,6 +23,9 @@
 .home_button .menu_bar_button GtkLabel {
     color: @menu_bar_inactive;
 }
+.home_button GtkLabel:insensitive {
+    background: transparent;
+}
 .home_button_active .menu_bar_button_active GtkLabel {
     color: @menu_bar_active;
 }
@@ -72,6 +75,9 @@
 .menu_bar_button GtkLabel {
     font: Bariol Bold 13;
     color: @menu_bar_inactive;
+}
+.menu_bar_button GtkLabel:insensitive {
+    background: transparent;
 }
 .menu_bar_button.selected GtkLabel {
     color: @menu_bar_active;


### PR DESCRIPTION
This change renders the Menu Bar buttons (Home, Badges, Character) insensitive while editing the character.

That prevents leaving the avatar creator class in a weird state.

Many thanks to @carolineclark for helping me with the CSS 