### PR TITLE
registration tracking: Adding new events

### DIFF
--- a/kano_registration_gui/RegistrationScreen1.py
+++ b/kano_registration_gui/RegistrationScreen1.py
@@ -14,6 +14,7 @@ from kano_registration_gui.GetData import GetData2
 from kano_registration_gui.RegistrationScreen2 import RegistrationScreen2
 from kano_world.functions import request_wrapper, content_type_json
 from kano.network import is_internet
+from kano_profile.tracker import track_data
 
 
 # Get username, password and birthday data from user.
@@ -89,6 +90,8 @@ class RegistrationScreen1(Gtk.Box):
             return
 
         if not self.is_username_available(username):
+            track_data('world-registration-username-taken',
+                       {'username': username})
             kd = KanoDialog(
                 "This username is taken!",
                 "Try another one",

--- a/kano_registration_gui/RegistrationScreen2.py
+++ b/kano_registration_gui/RegistrationScreen2.py
@@ -20,6 +20,7 @@ from kano_profile.paths import bin_dir
 from kano.network import is_internet
 from kano.logging import logger
 from kano.utils import run_bg
+from kano_profile.tracker import track_data
 
 
 # Get emails and show the terms and conditions
@@ -142,6 +143,7 @@ class RegistrationScreen2(Gtk.Box):
                     title=_("Houston, we have a problem"),
                     description=str(text)
                 )
+                track_data('world-registration-failed', {'reason': text})
 
         else:
             logger.info('registration successful')


### PR DESCRIPTION
This will trigger an event when an user tries an username but it's already taken and also when the registration fails.

world-registration-username-taken
world-registration-failed

cc @carolineclark 