### PR TITLE
Correct method name remove_items->remove_all.

### DIFF
--- a/kano_registration_gui/BirthdayWidget.py
+++ b/kano_registration_gui/BirthdayWidget.py
@@ -103,7 +103,7 @@ class BirthdayWidget(Gtk.Box):
         if year == 0 or month == 0:
             logger.debug("returning as year or month is blank, year = {}, month = {}".format(year, month))
             # Update the days as an empty list
-            self._day_dropdown.remove_items()
+            self._day_dropdown.remove_all()
             self._day_dropdown.set_text("Day")
             return
 


### PR DESCRIPTION
 This is a call to a nonexistent method, I think this is the one meant. Spotted on jessie, but I don't think it's a jessie issue.
@carolineclark @pazdera 