### PR TITLE
Option to disable sync for CharacterCreator class

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-profile (2.2.0-3) unstable; urgency=low
+
+  * Add optional arguments for use by the init flow
+
+ -- Team Kano <dev@kano.me>  Thu, 15 Oct 2015 17:00:00 +0100
+
 kano-profile (2.2.0-2) unstable; urgency=low
 
   * Add Kano World interraction functions

--- a/kano_avatar_gui/CharacterCreator.py
+++ b/kano_avatar_gui/CharacterCreator.py
@@ -25,7 +25,7 @@ class CharacterCreator(Gtk.EventBox):
     avatar_cr = AvatarCreator(configuration)
     meny_y_pos = 20
 
-    def __init__(self, randomise=False):
+    def __init__(self, randomise=False, no_sync=False):
         Gtk.EventBox.__init__(self)
 
         # This is the avatar specific styling
@@ -37,7 +37,7 @@ class CharacterCreator(Gtk.EventBox):
 
         # Check profile information and load up either the created avatar or
         # the default
-        self._create_menu()
+        self._create_menu(no_sync=no_sync)
         self._create_img_box(self.get_image_path())
 
         # This needs to be called after _create_menu()
@@ -121,8 +121,8 @@ class CharacterCreator(Gtk.EventBox):
         self._menu.hide_pop_ups()
         self._menu.unselect_categories()
 
-    def _create_menu(self):
-        self._menu = Menu(self.avatar_cr)
+    def _create_menu(self, no_sync=False):
+        self._menu = Menu(self.avatar_cr, no_sync=no_sync)
         self._menu.connect('asset_selected', self._update_img)
         self._menu.connect('randomise_all', self._randomise_avatar_wrapper)
 

--- a/kano_avatar_gui/Menu.py
+++ b/kano_avatar_gui/Menu.py
@@ -28,11 +28,11 @@ class Menu(Gtk.Fixed):
         'randomise_all': (GObject.SIGNAL_RUN_FIRST, None, ())
     }
 
-    def __init__(self, parser):
+    def __init__(self, parser, no_sync=False):
         Gtk.Fixed.__init__(self)
 
         self._parser = parser
-        char, item = get_avatar()
+        char, item = get_avatar(sync=not no_sync)
         self._parser.char_select(char)
         self._cat_menu = CategoryMenu(self._parser)
         self._cat_menu.connect('category_item_selected',
@@ -48,7 +48,7 @@ class Menu(Gtk.Fixed):
         self.put(self._cat_menu, 0, 0)
 
         self._initialise_pop_up_menus()
-        self._create_start_up_image()
+        self._create_start_up_image(char_item_tup=(char,item))
         self.show_all()
 
     def select_category_button(self, identifier):
@@ -112,7 +112,7 @@ class Menu(Gtk.Fixed):
                 self.remove(pop_up)
                 pop_up.destroy()
 
-    def _create_start_up_image(self):
+    def _create_start_up_image(self, char_item_tup=None, env=None):
         '''We check what has been saved on kano-profile, and we use a default if
         something hasn't been specified
         '''
@@ -121,8 +121,13 @@ class Menu(Gtk.Fixed):
         # This is a dictionary so we can eaily reset the menus
         self.saved_selected_list = {}
 
-        char, item = get_avatar()
-        env = get_environment()
+        if char_item_tup is None:
+            char, item = get_avatar()
+        else:
+            char, item = char_item_tup
+
+        if env is None:
+            env = get_environment()
 
         item[self._parser.char_label] = char
         item[self._parser.env_label] = env


### PR DESCRIPTION
This is necessary to avoid trying to sync and regenerate the character
in the init flow when we know that it is not there but the assets
will get generated anyway