### PR TITLE
Improved kano-share appearance

### DIFF
--- a/bin/kano-share
+++ b/bin/kano-share
@@ -38,13 +38,14 @@ from kano.gtk3.scrolled_window import ScrolledWindow
 from kano.gtk3.apply_styles import apply_common_to_screen
 from kano.gtk3.application_window import ApplicationWindow
 from kano.logging import logger
+from kano.gtk3.apply_styles import apply_styling_to_screen
+from kano_profile_gui.paths import css_dir
 
 
 def make_share_list():
     row_height = 70
 
     grid = Gtk.Grid()
-    grid.set_row_spacing(0)
     grid.set_size_request(400, 400)
 
     if len(sys.argv) == 2:
@@ -66,30 +67,49 @@ def make_share_list():
         sys.exit('Error with listing shares, error: {}'.format(text))
 
     for i, entry in enumerate(data['entries']):
-        row = Gtk.EventBox()
-        grid.attach(row, 0, i, 1, 1)
+        # Backgrounds of the three components in the row
+        background1 = Gtk.EventBox()
+        background2 = Gtk.EventBox()
+        background3 = Gtk.EventBox()
 
         if i % 2:
-            row.get_style_context().add_class('appgrid_grey')
+            background1.get_style_context().add_class('appgrid_grey')
+            background2.get_style_context().add_class('appgrid_grey')
+            background3.get_style_context().add_class('appgrid_grey')
+        else:
+            background1.get_style_context().add_class('white')
+            background2.get_style_context().add_class('white')
+            background3.get_style_context().add_class('white')
 
-        row_grid = Gtk.Grid()
-        row.add(row_grid)
-
-        has_url = bool(entry['attachment_url'])
+        grid.attach(background1, 0, i, 1, 1)
+        grid.attach(background2, 1, i, 1, 1)
+        grid.attach(background3, 2, i, 1, 1)
 
         label = Gtk.Label(entry['app'])
         label.set_size_request(50, row_height)
-        row_grid.attach(label, 0, 0, 1, 3)
+        label.get_style_context().add_class("menu_text")
+        label.set_alignment(0, 0.5)
+        label.set_margin_left(20)
+        background1.add(label)
 
         label = Gtk.Label(entry['title'])
         label.set_size_request(250, row_height)
-        row_grid.attach(label, 1, 0, 1, 3)
+        label.get_style_context().add_class("menu_text")
+        label.set_alignment(0, 0.5)
+        label.set_margin_left(20)
+        background2.add(label)
+
+        has_url = bool(entry['attachment_url'])
 
         if has_url:
             button = KanoButton(_('Download').upper())
             button.set_size_request(100, 30)
+            button.set_margin_top(15)
+            button.set_margin_bottom(15)
+            button.set_margin_left(20)
+            button.set_margin_right(20)
             button.connect('clicked', load_share, entry)
-            row_grid.attach(button, 2, 1, 1, 1)
+            background3.add(button)
 
     align = Gtk.Alignment(xalign=0.5, yalign=0.5, xscale=0, yscale=0)
     padding = 20
@@ -104,7 +124,6 @@ def load_share(button, entry):
     if not success:
         logger.error('Could not download share, error: {}'.format(data))
         window = button.get_toplevel()
-        print "window = {}".format(window)
         confirm = KanoDialog(
             _('Oops! Can\'t download.'),
             _('Are you sure you\'re connected to the Internet?'),
@@ -136,6 +155,7 @@ class MainWindow(ApplicationWindow):
         self.set_position(Gtk.WindowPosition.CENTER)
         self.set_resizable(False)
         self.set_decorated(True)
+        apply_styling_to_screen(os.path.join(css_dir, "share.css"))
 
         top_bar = TopBar('Kano Share', self.width)
         top_bar.set_close_callback(Gtk.main_quit)
@@ -152,6 +172,7 @@ class MainWindow(ApplicationWindow):
         scrolledwindow.set_size_request(
             self.width, self.height - top_bar.height)
         self.set_main_widget(scrolledwindow)
+        self.show_all()
 
 
 def main():

--- a/media/CSS/share.css
+++ b/media/CSS/share.css
@@ -1,0 +1,8 @@
+.menu_text {
+    font: Bariol Bold 14px;
+    color: #323232;
+}
+
+.white {
+    background: #ffffff;
+}


### PR DESCRIPTION
Improved from 
![kano-screenshot-wed-oct-21-15-14-02](https://cloud.githubusercontent.com/assets/5319573/10639225/07665838-7807-11e5-9974-cdfaf888fbc2.png)
to
![kano-screenshot-thu-oct-22-09-54-35](https://cloud.githubusercontent.com/assets/5319573/10660981/f0c21c42-78a2-11e5-9f5a-b9b250875720.png)

This is valid for master too as the layout is improved from 
![kano-screenshot-thu-oct-22-09-55-00](https://cloud.githubusercontent.com/assets/5319573/10660980/ebf04978-78a2-11e5-8579-c570db57127a.png)