### PR TITLE
Complete missing information for the make light shares

### DIFF
--- a/rules/app_profiles.json
+++ b/rules/app_profiles.json
@@ -43,6 +43,7 @@
     "icon": "linux-story.png"
   },
   "make-light": {
+    "dir": "Light-content",
     "cmd": "$(dpkg -l make-light > /dev/null 2>&1); if [ \"$?\" -eq 0 ] ; then $(make-light {fullpath}); else $(kano-apps install powerup);fi",
     "ext": "lightcode"
   },


### PR DESCRIPTION
This is needed to allow the kano-world-hooks to store and open shares from kano World