### PR TITLE
Profile sync fixes

### DIFF
--- a/bin/kano-sync
+++ b/bin/kano-sync
@@ -70,19 +70,21 @@ def do_login(silent=False, dialog=True):
     if not login_success:
         logger.debug('token login not successful msg: {}'.format(value))
         if silent:
-            logger.debug('exiting because of --silent')
+            logger.debug(
+                "Can't login, exiting gracefully because of the --silent flag"
+            )
             return False
-        else:
-            logger.debug('trying to log in with kano-login')
-            run_cmd(dir_path + '/bin/kano-login')
-            login_success, value = login_using_token()
-            if not login_success:
-                display_msg(
-                    'Login not possible, error: {} error'.format(value),
-                    'error',
-                    dialog=dialog
-                )
-                return False
+
+        logger.debug('trying to log in with kano-login')
+        run_cmd(os.path.join(dir_path, 'bin', 'kano-login'))
+        login_success, value = login_using_token()
+        if not login_success:
+            display_msg(
+                'Login not possible, error: {}'.format(value),
+                'error',
+                dialog=dialog
+            )
+            return False
     return True
 
 
@@ -90,6 +92,25 @@ def _any_notifications_available(profile):
     return ('notifications' in profile and
             type(profile['notifications']) is list and
             len(profile['notifications']) > 0)
+
+
+def _display_notifications():
+    profile = load_profile()
+    if _any_notifications_available(profile):
+        for n in profile['notifications']:
+            image = n["image"] if "image" in n else None
+            command = n["command"] if "command" in n else None
+            sound = n["sound"] if "sound" in n else None
+            display_generic_notification(
+                n["title"], n["byline"], image, command, sound, "world"
+            )
+
+            mark_notification_read(n['id'])
+
+        profile['last_notifications_prompt'] = int(time.time())
+        save_profile(profile, skip_kdesk_refresh=True)
+    else:
+        logger.debug('No notifications to show')
 
 
 def do_sync(skip_kdesk_refresh=False, dialog=True):
@@ -104,30 +125,17 @@ def do_sync(skip_kdesk_refresh=False, dialog=True):
         )
         return False
 
-    if not skip_kdesk_refresh:
-        refresh_kdesk()
-
     # Push notifications
     try:
-        profile = load_profile()
-        if _any_notifications_available(profile):
-            for n in profile['notifications']:
-                image = n["image"] if "image" in n else None
-                command = n["command"] if "command" in n else None
-                sound = n["sound"] if "sound" in n else None
-                display_generic_notification(n["title"], n["byline"],
-                                             image, command, sound,
-                                             "world")
-
-                mark_notification_read(n['id'])
-
-            profile['last_notifications_prompt'] = int(time.time())
-            save_profile(profile)
-        else:
-            logger.debug('No notifications to show')
+        _display_notifications()
     except Exception as e:
-        logger.warn("Unable to display notifications due to an exception "
-                    "({}: {})".format(e.__class__.__name__, str(e)))
+        logger.warn(
+            "Unable to display notifications due to an exception ({})"
+            .format(e)
+        )
+
+    if not skip_kdesk_refresh:
+        refresh_kdesk()
 
     display_msg('Sync OK', 'info', dialog=dialog)
     return True

--- a/bin/kano-sync
+++ b/bin/kano-sync
@@ -6,12 +6,30 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 
+"""
+Sync your local Kano profile to Kano World
+
+Usage:
+    kano-sync [-s ][-d] [--sync] [--backup] [--restore] [--upload-tracking-data] [--skip-kdesk]
+    kano-sync -h | --help
+
+Options:
+    -h, --help    Show this screen
+    -s, --silent  Silent mode, makes failures quiet
+    -d, --dialog  Display dialog
+    --sync        Sync Profile Data
+    --backup      Backup app content
+    --restore     Restore app content
+    --skip-kdesk  Skip kdesk refresh (happens at the end of sync and restore)
+"""
+
 import os
 import sys
-import argparse
 import time
 import tempfile
 from sys import platform as _platform
+
+from docopt import docopt
 
 if __name__ == '__main__' and __package__ is None:
     dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -20,8 +38,8 @@ if __name__ == '__main__' and __package__ is None:
 
 from kano_world.functions import sync, login_using_token, backup_content, \
     restore_content, upload_tracking_data, mark_notification_read
-from kano.utils import get_home, ensure_dir, run_cmd, read_json, delete_file, \
-    run_bg, is_gui, delete_dir
+from kano.utils import get_home, run_cmd, read_json, delete_file, run_bg, \
+    is_gui, delete_dir
 from kano_profile.paths import app_profiles_file
 from kano.logging import logger
 from kano_profile.profile import load_profile, save_profile
@@ -29,25 +47,9 @@ from kano.notifications import display_generic_notification
 
 home_dir = get_home()
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-s', '--silent', action='store_true', help='silent mode')
-parser.add_argument('-d', '--dialog', action='store_true',
-                    help='display dialog')
-parser.add_argument('--sync', action='store_true', help='sync profile data')
-parser.add_argument('--upload-tracking-data', action='store_true',
-                    help='upload tracking data')
-parser.add_argument('--backup', action='store_true', help='backup app content')
-parser.add_argument('--restore', action='store_true',
-                    help='restore app content')
-parser.add_argument('--skip-kdesk', action='store_true',
-                    help='skip kdesk refresh')
-args = parser.parse_args()
 
-enable_dialog = args.dialog and is_gui()
-
-
-def display_msg(msg, level):
-    if enable_dialog:
+def display_msg(msg, level, dialog=True):
+    if dialog and is_gui():
         from kano.gtk3.kano_dialog import KanoDialog
 
         kdialog = KanoDialog(msg, "")
@@ -59,7 +61,7 @@ def display_msg(msg, level):
         logger.error(msg)
 
 
-def do_login():
+def do_login(silent=False, dialog=True):
     logger.debug('do_login')
 
     # login first with token, if not working then try with dialog
@@ -67,31 +69,43 @@ def do_login():
     login_success, value = login_using_token()
     if not login_success:
         logger.debug('token login not successful msg: {}'.format(value))
-        if args.silent:
+        if silent:
             logger.debug('exiting because of --silent')
-            sys.exit()
+            return False
         else:
             logger.debug('trying to log in with kano-login')
             run_cmd(dir_path + '/bin/kano-login')
             login_success, value = login_using_token()
             if not login_success:
-                display_msg('Login not possible, error: ' + value, 'error')
-                sys.exit(1)
+                display_msg(
+                    'Login not possible, error: {} error'.format(value),
+                    'error',
+                    dialog=dialog
+                )
+                return False
+    return True
+
 
 def _any_notifications_available(profile):
     return ('notifications' in profile and
             type(profile['notifications']) is list and
             len(profile['notifications']) > 0)
 
-def do_sync():
+
+def do_sync(skip_kdesk_refresh=False, dialog=True):
     logger.debug('do_sync')
 
     success, value = sync()
     if not success:
-        display_msg('Sync not possible, error: {}'.format(value), 'error')
-        return
+        display_msg(
+            'Sync not possible, error: {}'.format(value),
+            'error',
+            dialog=dialog
+        )
+        return False
 
-    refresh_kdesk()
+    if not skip_kdesk_refresh:
+        refresh_kdesk()
 
     # Push notifications
     try:
@@ -115,10 +129,11 @@ def do_sync():
         logger.warn("Unable to display notifications due to an exception "
                     "({}: {})".format(e.__class__.__name__, str(e)))
 
-    display_msg('Sync OK', 'info')
+    display_msg('Sync OK', 'info', dialog=dialog)
+    return True
 
 
-def do_backup():
+def do_backup(dialog=True):
     logger.debug('do_backup')
 
     os.chdir(home_dir)
@@ -144,22 +159,22 @@ def do_backup():
     _, e, _ = run_cmd(tar_cmd)
     if e:
         msg = 'Error with compressing backup data: {}'.format(e)
-        display_msg(msg, 'error')
+        display_msg(msg, 'error', dialog=dialog)
         delete_dir(tmp_dir)
         return
 
     success, error = backup_content(tmp_file)
     if not success:
         msg = 'Error with uploading backup data: {}'.format(e)
-        display_msg(msg, 'error')
+        display_msg(msg, 'error', dialog=dialog)
     else:
-        display_msg('Backup OK', 'info')
+        display_msg('Backup OK', 'info', dialog=dialog)
 
     delete_file(tmp_file)
     delete_dir(tmp_dir)
 
 
-def do_restore():
+def do_restore(skip_kdesk_refresh=False, dialog=True):
     logger.debug('do_restore')
 
     os.chdir(home_dir)
@@ -171,7 +186,7 @@ def do_restore():
     success, error = restore_content(tmp_file)
     if not success:
         msg = 'Error with downloading restore data: ' + error
-        display_msg(msg, 'error')
+        display_msg(msg, 'error', dialog=dialog)
         delete_dir(tmp_dir)
         return
 
@@ -183,49 +198,64 @@ def do_restore():
     _, e, _ = run_cmd(tar_cmd)
     if e:
         msg = 'Error with uncompressing restore data: {}'.format(e)
-        display_msg(msg, 'error')
+        display_msg(msg, 'error', dialog=dialog)
 
-    refresh_kdesk()
+    if not skip_kdesk_refresh:
+        refresh_kdesk()
 
     delete_file(tmp_file)
     delete_dir(tmp_dir)
 
-    display_msg('Restore OK', 'info')
+    display_msg('Restore OK', 'info', dialog=dialog)
 
 
-def do_upload_tracking_data():
+def do_upload_tracking_data(dialog=True):
     logger.debug('do_upload_tracking_data')
 
     success, value = upload_tracking_data()
     if not success:
-        display_msg('Upload not possible, error: {}'.format(value), 'error')
+        display_msg(
+            'Upload not possible, error: {}'.format(value),
+            'error',
+            dialog=dialog
+        )
         return
 
 
 def refresh_kdesk():
-    if args.skip_kdesk:
-        return
-
     logger.info('refreshing kdesk from kano-sync')
     if os.path.exists('/usr/bin/kdesk'):
         run_bg('kdesk -a profile ; kdesk -a world')
 
 
+def main(args):
+
+    skip_kdesk_refresh = args['--skip-kdesk']
+    dialog = args['--dialog']
+    silent = args['--silent']
+
+    login_successful = do_login(silent=silent, dialog=dialog)
+    if login_successful:
+        if args['--sync']:
+            do_sync(skip_kdesk_refresh=skip_kdesk_refresh, dialog=dialog)
+
+        if args['--backup']:
+            do_backup(dialog=dialog)
+
+        if args['--restore']:
+            do_restore(skip_kdesk_refresh=skip_kdesk_refresh, dialog=dialog)
+
+        if args['--upload-tracking-data']:
+            do_upload_tracking_data(dialog=dialog)
+        return 0
+    else:
+        # We want to refresh kdesk even if the user is not, or can't log in
+        if not skip_kdesk_refresh:
+            refresh_kdesk()
+        return 1
+
+
 if __name__ == '__main__':
-    if not (args.sync or args.backup or args.restore or args.upload_tracking_data):
-        parser.print_help()
-        sys.exit()
-
-    do_login()
-
-    if args.sync:
-        do_sync()
-
-    if args.backup:
-        do_backup()
-
-    if args.restore:
-        do_restore()
-
-    if args.upload_tracking_data:
-        do_upload_tracking_data()
+    args = docopt(__doc__)
+    rc = main(args)
+    sys.exit(rc)

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ kano-profile (2.3.0-2) unstable; urgency=low
     is missing
   * Added many items for the character creator that were previously available
     only through kano-content
+  * kano-sync now uses docopt
+  * Reduce no of syncs and kdesk refreshes
 
  -- Team Kano <dev@kano.me>  Tue, 12 Jan 2016 11:38:00 +0000
 

--- a/kano_avatar/logic.py
+++ b/kano_avatar/logic.py
@@ -13,7 +13,7 @@ from kano_avatar.paths import (AVATAR_CONF_FILE,
 from kano.logging import logger
 
 from kano_profile.profile import (set_avatar, set_environment,
-                                  save_profile_variable)
+                                  save_profile_variable, sync_profile)
 from kano.utils import get_date_now
 from kano_content.api import ContentManager
 from kano_content.extended_paths import content_dir
@@ -488,9 +488,10 @@ class AvatarCreator(AvatarConfParser):
             items_no_env.pop(self.env_label, None)
             # When saving a new character in the profile, ensure that
             # the right version is used to sync with the API
-            save_profile_variable('version', 2)
-            set_avatar(self._sel_char.get_id(), items_no_env)
-            set_environment(self._sel_env.get_id(), sync=True)
+            save_profile_variable('version', 2, skip_kdesk_refresh=True)
+            set_avatar(self._sel_char.get_id(), items_no_env, sync=False)
+            set_environment(self._sel_env.get_id(), sync=False)
+            sync_profile()
 
         return True
 

--- a/kano_login/login.py
+++ b/kano_login/login.py
@@ -219,16 +219,20 @@ class Login(Gtk.Box):
             first_sync_done = False
 
         if not first_sync_done:
-            logger.info('running kano-sync --sync && --sync && --restore after first time login')
+            logger.info(
+                'running kano-sync --sync --restore after first time login'
+            )
 
-            # doing first sync and restore
-            cmd1 = '{bin_dir}/kano-sync --sync -s'.format(bin_dir=bin_dir)
-            cmd2 = '{bin_dir}/kano-sync --sync -s'.format(bin_dir=bin_dir)
-            cmd3 = '{bin_dir}/kano-sync --restore -s'.format(bin_dir=bin_dir)
-            cmd = "{} && {} && {}".format(cmd1, cmd2, cmd3)
+            # When both --sync and --restore are given as options, sync occurs
+            # before the restore
+            cmd = '{bin_dir}/kano-sync --sync -s --restore'.format(bin_dir=bin_dir)
             run_bg(cmd)
 
-            save_profile_variable('first_sync_done', True)
+            save_profile_variable(
+                'first_sync_done',
+                True,
+                skip_kdesk_refresh=True
+            )
 
         else:
             logger.info('running kano-sync --sync after non-first login')

--- a/kano_profile/badges.py
+++ b/kano_profile/badges.py
@@ -14,7 +14,7 @@ import itertools
 from copy import deepcopy
 
 from kano.logging import logger
-from kano.utils import read_json, is_gui, is_running, run_bg
+from kano.utils import read_json, is_gui, run_bg
 from .paths import xp_file, levels_file, rules_dir, bin_dir, \
     app_profiles_file, online_badges_dir, online_badges_file
 from .apps import load_app_state, get_app_list, save_app_state
@@ -343,11 +343,6 @@ def save_app_state_with_dialog(app_name, data):
     new_level_str = ''
     if old_level != new_level:
         new_level_str = 'level:{}'.format(new_level)
-
-        # A new level has been reached, update the desktop profile icon
-        if os.path.exists('/usr/bin/kdesk') and not is_running('kano-sync'):
-            logger.info('refreshing kdesk due to new experience level')
-            run_bg('kdesk -a profile')
 
     # new items
     new_items_str = ''

--- a/kano_registration_gui/RegistrationScreen2.py
+++ b/kano_registration_gui/RegistrationScreen2.py
@@ -149,7 +149,11 @@ class RegistrationScreen2(Gtk.Box):
             logger.info('registration successful')
 
             bday_date = str(datetime.date(date_year, date_month, date_day))
-            save_profile_variable('birthdate', bday_date)
+            save_profile_variable(
+                'birthdate',
+                bday_date,
+                skip_kdesk_refresh=True
+            )
 
             # saving hardware info and initial Kano version
             save_hardware_info()

--- a/kano_world/session.py
+++ b/kano_world/session.py
@@ -204,7 +204,11 @@ class KanoWorldSession(object):
 
         try:
             version_no = data['user']['avatar']['generator']['version']
-            save_profile_variable('version', version_no)
+            save_profile_variable(
+                'version',
+                version_no,
+                skip_kdesk_refresh=True
+            )
         except Exception:
             pass
 
@@ -215,10 +219,14 @@ class KanoWorldSession(object):
             if data['user']['avatar']['generator']['version'] == 2:
                 gen = data['user']['avatar']['generator']
                 avatar_subcat, avatar_item = gen['character']
-                updated_locally = set_avatar(avatar_subcat, avatar_item)
+                updated_locally = set_avatar(
+                    avatar_subcat,
+                    avatar_item,
+                    sync=False
+                )
 
                 environment = gen['environment'][1]
-                updated_locally |= set_environment(environment)
+                updated_locally |= set_environment(environment, sync=False)
 
         except Exception:
             pass


### PR DESCRIPTION
At the moment we tend to over use kano-sync. This causes the kit to be slow, since we often perform syncs multiple times.

This PR should reduce the amount of times we sync and cause a kdesk refresh to those absolutely necessary.

Work towards https://github.com/KanoComputing/peldins/issues/2187