### PR TITLE
Add update_upwards fn

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,7 @@ kano-profile (2.3.0-2) unstable; urgency=low
   * Reduce no of syncs and kdesk refreshes
   * Updated xp allocation for Make Light
   * Add app progress helpers
+  * Add update_upwards app variable helper functions
 
  -- Team Kano <dev@kano.me>  Tue, 12 Jan 2016 11:38:00 +0000
 

--- a/kano_profile/apps.py
+++ b/kano_profile/apps.py
@@ -89,6 +89,29 @@ def save_app_state_variable(app_name, variable, value):
     save_app_state(app_name, data)
 
 
+def update_upwards(app_name, variable, value):
+    """ Only update a numeric value in the profile if the one given is higher.
+    Useful for highscores, etc
+
+    :param app_name: The application that this variable is associated with.
+    :type app_name: str
+
+    :param variable: The name of the variable.
+    :type data: str
+
+    :param value: The value to be stored if it is higher that the one already
+                  stored
+    :type data: numeric
+    """
+    msg = "update_increasingly {} {} {}".format(app_name, variable, value)
+    logger.debug(msg)
+    data = load_app_state(app_name)
+    if data.get(variable, 0) < value:
+        data[variable] = value
+
+        save_app_state(app_name, data)
+
+
 def increment_app_state_variable(app_name, variable, value):
     logger.debug(
         'increment_app_state_variable {} {} {}'.format(

--- a/kano_profile/badges.py
+++ b/kano_profile/badges.py
@@ -390,6 +390,31 @@ def save_app_state_variable_with_dialog(app_name, variable, value):
     save_app_state_with_dialog(app_name, data)
 
 
+def update_upwards_with_dialog(app_name, variable, value):
+    """ Only update a numeric value in the profile if the one given is higher.
+    Useful for highscores, etc
+
+    :param app_name: The application that this variable is associated with.
+    :type app_name: str
+
+    :param variable: The name of the variable.
+    :type data: str
+
+    :param value: The value to be stored if it is higher that the one already
+                  stored
+    :type data: numeric
+    """
+    msg = "update_increasingly_with_dialog {} {} {}".format(
+        app_name, variable, value
+    )
+    logger.debug(msg)
+    data = load_app_state(app_name)
+    if data.get(variable, 0) < value:
+        data[variable] = value
+
+        save_app_state_with_dialog(app_name, data)
+
+
 def increment_app_state_variable_with_dialog(app_name, variable, value):
     logger.debug(
         'increment_app_state_variable_with_dialog {} {} {}'


### PR DESCRIPTION
This is a helper function to allow us to update metrics such as a high score.

It is moving away from the really long function name convention of the module. The module name itself makes it clear which data these functions operate on.

Related to: https://github.com/KanoComputing/peldins/issues/2249