### PR TITLE
Disable minimize/maximize Kano World when in Dashboard mode

### DIFF
--- a/bin/kano-world-launcher
+++ b/bin/kano-world-launcher
@@ -43,6 +43,7 @@ class epiphany_browser:
 
     def get_cmd(self, url, token, redirect):
         # get command to launch browser with no url bar
+        # TODO: Hide the minimize and maximize buttons if in Dashboard mode
         return "epiphany  -a --profile={} {}/login/{}{}".format(self.epiphany_folder, url, token, redirect)
     
 class chromium_browser:
@@ -94,9 +95,16 @@ class chromium_browser:
         write_json(self.chromium_local_state, data)
         
     def get_cmd(self, url, token, redirect):
-        # get command to launch browser with no url bar
-        return "chromium --window-size=1000,700 --app={}/login/{}{}".format(url, token, redirect)
-        
+        # Get command to launch browser with no url bar
+        if os.getenv('KANO_BLOCKS_SCREEN_HEIGHT'):
+            # If in Dashboard mode, use kano Gtk based webview,
+            # so that we can hide the maximize and minimize buttons.
+            cmdline='kano-web-view --title "Kano World" --decorate --no-minmax {}/login/{}{}'.format(url, token, redirect)
+        else:
+            cmdline="chromium --window-size=1000,700 --app={}/login/{}{}".format(url, token, redirect)
+
+        return cmdline
+
 
 # Check internet status
 if not is_internet():

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, kano-toolset (>=2.3.0-5),
          gir1.2-gtk-3.0, libkdesk-dev, kano-widgets (>=1.2.4-3), python-yaml,
          kano-settings (>=1.3-2), xtoolwait, python-imaging, kano-i18n,
-         kano-content
+         kano-content, kano-web-view
 Recommends: kano-fonts
 Description: Profile app for KANO
 Provides: kano-share


### PR DESCRIPTION
 * If working in Dashboard mode, kano world will not have the min/max buttons
 * Resolved by changing Chromium to Kano web view, Gtk based browser
 * Possibly need to address same alternative if using Epiphany
 * Note that the change does not resolve starting shares from the browser.
