### PR TITLE
Write badge notifications to two fifos, one for the dashboard

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 Package: kano-profile
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, kano-toolset (>=2.3.0-5),
-         gir1.2-gtk-3.0, libkdesk-dev, kano-widgets (>=1.2.4-3), python-yaml,
+         gir1.2-gtk-3.0, libkdesk-dev, kano-widgets (>=3.0.0-1), python-yaml,
          kano-settings (>=1.3-2), xtoolwait, python-imaging, kano-i18n,
          kano-content, kano-web-view
 Recommends: kano-fonts


### PR DESCRIPTION
This PR makes badge notifications get sent to both the dashboard and desktop notifications daemon.
I also took the opportunity to make this less likely to get blocked waiting for the fifo.
For https://github.com/KanoComputing/peldins/issues/2328
@tombettany @alex5imon 
