### PR TITLE
Fix shares

### DIFF
--- a/bin/kano-world-launcher
+++ b/bin/kano-world-launcher
@@ -43,7 +43,6 @@ class epiphany_browser:
 
     def get_cmd(self, url, token, redirect):
         # get command to launch browser with no url bar
-        # TODO: Hide the minimize and maximize buttons if in Dashboard mode
         return "epiphany  -a --profile={} {}/login/{}{}".format(self.epiphany_folder, url, token, redirect)
     
 class chromium_browser:
@@ -95,16 +94,9 @@ class chromium_browser:
         write_json(self.chromium_local_state, data)
         
     def get_cmd(self, url, token, redirect):
-        # Get command to launch browser with no url bar
-        if os.getenv('KANO_BLOCKS_SCREEN_HEIGHT'):
-            # If in Dashboard mode, use kano Gtk based webview,
-            # so that we can hide the maximize and minimize buttons.
-            cmdline='kano-web-view --title "Kano World" --decorate --no-minmax {}/login/{}{}'.format(url, token, redirect)
-        else:
-            cmdline="chromium --window-size=1000,700 --app={}/login/{}{}".format(url, token, redirect)
-
-        return cmdline
-
+        # get command to launch browser with no url bar
+        return "chromium --window-size=1000,700 --app={}/login/{}{}".format(url, token, redirect)
+        
 
 # Check internet status
 if not is_internet():

--- a/bin/kano-world-launcher
+++ b/bin/kano-world-launcher
@@ -92,11 +92,17 @@ class chromium_browser:
             }
         }
         write_json(self.chromium_local_state, data)
-        
+
     def get_cmd(self, url, token, redirect):
         # get command to launch browser with no url bar
-        return "chromium --window-size=1000,700 --app={}/login/{}{}".format(url, token, redirect)
-        
+        win = '--window-size=1000,700'
+
+        # If in dashboard mode, maximize
+        if os.getenv('KANO_BLOCKS_SCREEN_HEIGHT'):
+            win = win + ' --start-maximized'
+
+        return "chromium {} --app={}/login/{}{}".format(win, url, token, redirect)
+
 
 # Check internet status
 if not is_internet():

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python, kano-toolset (>=2.3.0-5),
          gir1.2-gtk-3.0, libkdesk-dev, kano-widgets (>=3.0.0-1), python-yaml,
          kano-settings (>=1.3-2), xtoolwait, python-imaging, kano-i18n,
-         kano-content, kano-web-view
+         kano-content
 Recommends: kano-fonts
 Description: Profile app for KANO
 Provides: kano-share


### PR DESCRIPTION
This PR reverts the change to use kano-web-view for kano-world, because that does not (yet) know about the 'kano' url scheme needed to launch shares.
I have at @tombettany 's suggestion still maximised the window in dashboard mode.
@skarbat @tombettany 