### PR TITLE
Fixed name of chromium process name

### DIFF
--- a/bin/kano-world-launcher
+++ b/bin/kano-world-launcher
@@ -43,7 +43,7 @@ class epiphany_browser:
 
     def get_cmd(self, url, token, redirect):
         # get command to launch browser with no url bar
-        return "epiphany  -a --profile={} {}/login/{}{}".format(self.epiphany_folder, url, token, redirect)
+        return "epiphany -a --profile={} {}/login/{}{}".format(self.epiphany_folder, url, token, redirect)
     
 class chromium_browser:
 
@@ -101,7 +101,7 @@ class chromium_browser:
         if os.getenv('KANO_BLOCKS_SCREEN_HEIGHT'):
             win = win + ' --start-maximized'
 
-        return "chromium {} --app={}/login/{}{}".format(win, url, token, redirect)
+        return "chromium-browser {} --app={}/login/{}{}".format(win, url, token, redirect)
 
 
 # Check internet status


### PR DESCRIPTION
 * The chromium process is not available anymore, replaced by chromium-browser.
 * Fixed the changing the binary name to open kano-world.

Just stumbled across this one while addressing a separate issue, @Ealdwulf @tombettany 
