### PR TITLE
Add token-session

### DIFF
--- a/kano_profile/tracker.py
+++ b/kano_profile/tracker.py
@@ -141,7 +141,8 @@ def session_start(name, pid=None):
         "started": int(time.time()),
         "elapsed": 0,
         "app_session_id": str(uuid5(uuid1(), name + str(pid))),
-        "finished": False
+        "finished": False,
+        "token-system": TOKEN
     }
 
     path = get_session_file_path(data['name'], data['pid'])
@@ -318,6 +319,7 @@ def get_session_event(session):
 
         "name": session['name'],
         "length": session['elapsed'],
+        "token-system": session.get('token-system', '')
     }
 
 


### PR DESCRIPTION
Add 'token-system' to  app sessions, so they are associated with the same session they are generated in.

For https://github.com/KanoComputing/peldins/issues/2416
Note that I haven't added this to independent events (the 'token' value there should already refer to the correct session) The PR also refers to the app session id as "token-app", it is currently called "app_session_id" - I assume it's not worth renaming it?
@alex5imon @delormev 

