### PR TITLE
Fixed registration form to create a KW account

### DIFF
--- a/kano_registration_gui/RegistrationScreen.py
+++ b/kano_registration_gui/RegistrationScreen.py
@@ -155,7 +155,7 @@ class RegistrationScreen(Gtk.Box):
             headers=content_type_json
         )
 
-        if not success and text.strip() == _("User not found"):
+        if not success and text.strip() == "User not found":
             return True
         elif success:
             # Username is definitely taken


### PR DESCRIPTION
It turns out that the issue here was that the code was comparing text returned
by the KW API with the translated version of that string. Eso no está bien.

@Ealdwulf @tombettany 