### PR TITLE
Tracking: Allow tracking sessions to be paused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ cscope.po.out
 # Ignore locked versions of original files
 media/images/environments/originals/**/*_locked.png
 media/images/badges/originals/**/*_locked.png
+
+# Test files
+.cache

--- a/bin/kano-tracker-ctl
+++ b/bin/kano-tracker-ctl
@@ -16,6 +16,8 @@ Usage:
   kano-tracker-ctl session (start|end) <name> <pid>
   kano-tracker-ctl session log <name> <started> <length>
   kano-tracker-ctl session run <name> <command>
+  kano-tracker-ctl pause-sessions
+  kano-tracker-ctl resume-sessions
   kano-tracker-ctl (+1|action) <name>
   kano-tracker-ctl data <name> <value>
   kano-tracker-ctl generate <event>
@@ -32,10 +34,10 @@ Usage:
 
 import sys
 import os
-import docopt
 import json
 import time
 import math
+import docopt
 
 if __name__ == '__main__' and __package__ is None:
     dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -43,12 +45,18 @@ if __name__ == '__main__' and __package__ is None:
         sys.path.insert(1, dir_path)
 
 from kano_profile.paths import tracker_dir, tracker_events_file
-from kano_profile.tracker import open_locked, session_start, session_end, \
-    get_session_file_path, track_action, track_data, get_session_event, \
-    session_log, generate_tracker_token, load_token, get_utc_offset, \
-    track_subprocess
+from kano_profile.tracker import track_subprocess, track_action
+from kano_profile.tracker.tracking_events import track_data
+from kano_profile.tracker.tracker_token import generate_tracker_token, \
+    load_token
+from kano_profile.tracker.tracking_sessions import session_start, session_end, \
+    get_session_file_path, get_session_event, session_log, \
+    pause_tracking_sessions, unpause_tracking_sessions
+from kano_profile.tracker.tracking_utils import open_locked, get_utc_offset
+
 from kano.logging import logger
-from kano.utils import delete_file, ensure_dir, is_running
+from kano.utils.file_operations import delete_file, ensure_dir
+from kano.utils.processes import is_running
 from kano.colours import decorate_string_only_terminal
 from kano_profile.tracking_events import generate_event
 
@@ -343,6 +351,10 @@ def main():
             session_log(args['<name>'], args['<started>'], args['<length>'])
         elif args['run']:
             track_subprocess(args['<name>'], args['<command>'])
+    elif args['pause-sessions']:
+        pause_tracking_sessions()
+    elif args['resume-sessions']:
+        unpause_tracking_sessions()
     elif args['+1'] or args['action']:
         track_action(args['<name>'])
     elif args['generate']:

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+from kano_profile.paths import tracker_dir
+
+
+def before_scenario(context, scenario):
+    # Clear out tracking sessions
+    for path, dirs, files in os.walk(tracker_dir):
+        for tracker_f in files:
+            os.remove(os.path.join(path, tracker_f))

--- a/features/tracker.feature
+++ b/features/tracker.feature
@@ -1,0 +1,71 @@
+Feature: App tracker
+
+    Scenario: An app runs and creates a tracking session
+        Given an app with tracking sessions is launched
+         When 2 seconds elapse
+          And the app closes
+         Then a tracking session exists
+          And there is a tracking session log for the app running for 2 seconds
+
+
+    Scenario: A tracked app is running and the session is paused
+        Given an app with tracking sessions is launched
+         When 1 seconds elapse
+          And the tracking session is paused
+          And 2 seconds elapse
+          And the tracking session is unpaused
+          And 2 seconds elapse
+         When the app closes
+         Then 2 tracking sessions exist
+          And there is a tracking session log for the 1st app running for 1 seconds
+          And there is a tracking session log for the 1st app running for 2 seconds
+
+
+    Scenario: The tracked app closes while the tracking is paused
+        Given the tracking session is paused
+         When 1 seconds elapse
+          And an app with tracking sessions is launched
+          And 2 seconds elapse
+          And the app closes
+          And 2 seconds elapse
+          And the tracking session is unpaused
+         Then no tracking sessions exist
+
+
+    Scenario: A tracked app opens and closes while the tracking is paused
+        Given an app with tracking sessions is launched
+         When 1 seconds elapse
+          And the tracking session is paused
+          And 2 seconds elapse
+          And the app closes
+          And 2 seconds elapse
+          And the tracking session is unpaused
+         Then a tracking session exists
+          And there is a tracking session log for the app running for 1 seconds
+
+
+    Scenario: The tracked app opens after the tracking is paused
+        Given the tracking session is paused
+         When 1 seconds elapse
+          And an app with tracking sessions is launched
+          And 2 seconds elapse
+          And the tracking session is unpaused
+          And 2 seconds elapse
+          And the app closes
+         Then a tracking session exists
+          And there is a tracking session log for the app running for 2 seconds
+
+
+    Scenario: Tracking pausing is requested multiple times
+        Given an app with tracking sessions is launched
+         When 1 seconds elapse
+          And the tracking session is paused
+          And 1 seconds elapse
+          And the tracking session is paused
+          And 1 seconds elapse
+          And the tracking session is unpaused
+          And 2 seconds elapse
+          And the app closes
+         Then 2 tracking sessions exist
+          And there is a tracking session log for the 1st app running for 1 seconds
+          And there is a tracking session log for the 1st app running for 2 seconds

--- a/kano_profile/tracker/__init__.py
+++ b/kano_profile/tracker/__init__.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
-
-# tracker.py
+#
+# __init__.py
 #
 # Copyright (C) 2014 - 2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2

--- a/kano_profile/tracker/__init__.py
+++ b/kano_profile/tracker/__init__.py
@@ -40,7 +40,7 @@ from kano_profile.paths import tracker_dir, tracker_events_file, \
 from kano_profile.tracker.tracker_token import TOKEN, generate_tracker_token, \
        load_token
 from kano_profile.tracker.tracking_utils import open_locked, \
-    _get_nearest_previous_monday, get_utc_offset
+    get_nearest_previous_monday, get_utc_offset
 
 # Public imports
 from kano_profile.tracker.tracker import Tracker
@@ -186,7 +186,7 @@ def add_runtime_to_app(app, runtime):
         if 'weekly' not in app_stats[app]:
             app_stats[app]['weekly'] = {}
 
-        week = str(_get_nearest_previous_monday())
+        week = str(get_nearest_previous_monday())
         if week not in app_stats[app]['weekly']:
             app_stats[app]['weekly'][week] = {
                 'starts': 0,

--- a/kano_profile/tracker/__init__.py
+++ b/kano_profile/tracker/__init__.py
@@ -17,36 +17,36 @@ __email__ = 'dev@kano.me'
 import time
 import atexit
 import datetime
-import fcntl
 import json
 import os
-import hashlib
 import subprocess
 import shlex
 
 from uuid import uuid1, uuid5
 
-from kano.utils.processes import get_program_name
 from kano.utils.file_operations import read_file_contents, chown_path, \
     ensure_dir
 from kano.utils.hardware import get_cpu_id
 from kano.utils.misc import is_number
 from kano.logging import logger
+
 from kano_profile.apps import get_app_state_file, load_app_state_variable, \
     save_app_state_variable
 from kano_profile.paths import tracker_dir, tracker_events_file, \
     tracker_token_file
-
 from kano_profile.tracker.tracker_token import TOKEN, generate_tracker_token, \
-       load_token
+	load_token
 from kano_profile.tracker.tracking_utils import open_locked, \
     get_nearest_previous_monday, get_utc_offset
+from kano_profile.tracker.tracking_session import TrackingSession
+from kano_profile.tracker.tracking_sessions import session_start, session_end, \
+    list_sessions, get_open_sessions, get_session_file_path, session_log, \
+	get_session_unique_id, get_session_event, CPU_ID, LANGUAGE, OS_VERSION
 
 # Public imports
 from kano_profile.tracker.tracker import Tracker
 from kano_profile.tracker.tracking_sessions import session_start, session_end, \
-    get_session_file_path, session_log, get_session_unique_id, \
-    get_session_event, CPU_ID, LANGUAGE, OS_VERSION
+    pause_tracking_sessions, unpause_tracking_sessions
 
 
 def track_data(name, data):
@@ -206,7 +206,8 @@ def save_hardware_info():
     """Saves hardware information related to the Raspberry Pi / Kano Kit"""
 
     from kano.logging import logger
-    from kano.utils import get_cpu_id, get_mac_address, detect_kano_keyboard
+    from kano.utils.hardware import get_cpu_id, get_mac_address, \
+        detect_kano_keyboard
 
     logger.info('save_hardware_info')
     state = {

--- a/kano_profile/tracker/__init__.py
+++ b/kano_profile/tracker/__init__.py
@@ -4,12 +4,15 @@
 # Copyright (C) 2014 - 2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
+# Kano-tracker module
+#
+# A small module for tracking various metrics the users do in Kano OS
+#
 
-"""
-Kano-tracker module
 
-A small module for tracking various metrics the users do in Kano OS
-"""
+__author__ = 'Kano Computing Ltd.'
+__email__ = 'dev@kano.me'
+
 
 import time
 import atexit
@@ -23,204 +26,27 @@ import shlex
 
 from uuid import uuid1, uuid5
 
-from kano.utils import get_program_name, is_number, read_file_contents, \
-    get_cpu_id, chown_path, ensure_dir
+from kano.utils.processes import get_program_name
+from kano.utils.file_operations import read_file_contents, chown_path, \
+    ensure_dir
+from kano.utils.hardware import get_cpu_id
+from kano.utils.misc import is_number
 from kano.logging import logger
 from kano_profile.apps import get_app_state_file, load_app_state_variable, \
     save_app_state_variable
 from kano_profile.paths import tracker_dir, tracker_events_file, \
     tracker_token_file
 
+from kano_profile.tracker.tracker_token import TOKEN, generate_tracker_token, \
+       load_token
+from kano_profile.tracker.tracking_utils import open_locked, \
+    _get_nearest_previous_monday, get_utc_offset
 
-class open_locked(file):
-    """ A version of open with an exclusive lock to be used within
-        controlled execution statements.
-    """
-    def __init__(self, *args, **kwargs):
-        super(open_locked, self).__init__(*args, **kwargs)
-        fcntl.flock(self, fcntl.LOCK_EX)
-
-
-def load_token():
-    """
-        Reads the tracker token from the token file. If the file doesn't
-        exists, it regenerates it.
-
-        The token is regenerated on each boot and is inserted into every
-        event to link together events that happened during the same start
-        of the OS.
-
-        :returns: The token.
-        :rtype: str
-    """
-
-    if os.path.exists(tracker_token_file):
-        try:
-            f = open_locked(tracker_token_file, 'r')
-        except IOError as e:
-            logger.error("Error opening tracker token file {}".format(e))
-        else:
-            with f:
-                return f.read().strip()
-    else:
-        return generate_tracker_token()
-
-
-def generate_tracker_token():
-    """
-        Generating the token is a simple md5hash of the current time.
-
-        The token is saved to the `tracker_token_file`.
-
-        :returns: The token.
-        :rtype: str
-    """
-
-    token = hashlib.md5(str(time.time())).hexdigest()
-
-    ensure_dir(tracker_dir)
-    try:
-        f = open_locked(tracker_token_file, 'w')
-    except IOError as e:
-        logger.error(
-            "Error opening tracker token file (generate) {}".format(e))
-    else:
-        with f:
-            f.write(token)
-        if 'SUDO_USER' in os.environ:
-            chown_path(tracker_token_file)
-
-    # Make sure that the events file exist
-    try:
-        f = open(tracker_events_file, 'a')
-    except IOError as e:
-        logger.error("Error opening tracker events file {}".format(e))
-    else:
-        f.close()
-        if 'SUDO_USER' in os.environ:
-            chown_path(tracker_events_file)
-
-    return token
-
-
-OS_VERSION = str(read_file_contents('/etc/kanux_version'))
-os_variant = read_file_contents('/etc/kanux_version_variant')
-OS_VERSION += '-' + os_variant if os_variant else ''
-CPU_ID = str(get_cpu_id())
-TOKEN = load_token()
-LANGUAGE = (os.getenv('LANG') or '').split('.', 1)[0]
-
-
-def get_session_file_path(name, pid):
-    return "{}/{}-{}.json".format(tracker_dir, pid, name)
-
-
-def get_session_unique_id(name, pid):
-    data = {}
-    tracker_session_file = get_session_file_path(name, pid)
-    try:
-        af = open_locked(tracker_session_file, 'r')
-    except (IOError, OSError) as e:
-        logger.error("Error while opening session file".format(e))
-    else:
-        with af:
-            try:
-                data = json.load(af)
-            except ValueError as e:
-                logger.error("Session file is not a valid JSON")
-
-    return data.get('app_session_id', "")
-
-
-def session_start(name, pid=None):
-    if not pid:
-        pid = os.getpid()
-    pid = int(pid)
-
-    data = {
-        'pid': pid,
-        'name': name,
-        'started': int(time.time()),
-        'elapsed': 0,
-        'app_session_id': str(uuid5(uuid1(), name + str(pid))),
-        'finished': False,
-        'token-system': TOKEN
-    }
-
-    path = get_session_file_path(data['name'], data['pid'])
-
-    try:
-        f = open_locked(path, 'w')
-    except IOError as e:
-        logger.error("Error opening tracker session file {}".format(e))
-    else:
-        with f:
-            json.dump(data, f)
-        if 'SUDO_USER' in os.environ:
-            chown_path(path)
-
-    return path
-
-
-def session_end(session_file):
-    if not os.path.exists(session_file):
-        msg = "Someone removed the tracker file, the runtime of this " \
-              "app will not be logged"
-        logger.warn(msg)
-        return
-
-    try:
-        rf = open_locked(session_file, 'r')
-    except IOError as e:
-        logger.error("Error opening the tracker session file {}".format(e))
-    else:
-        with rf:
-            data = json.load(rf)
-
-            data['elapsed'] = int(time.time()) - data['started']
-            data['finished'] = True
-
-            try:
-                wf = open(session_file, 'w')
-            except IOError as e:
-                logger.error(
-                    "Error opening the tracker session file {}".format(e))
-            else:
-                with wf:
-                    json.dump(data, wf)
-        if 'SUDO_USER' in os.environ:
-            chown_path(session_file)
-
-
-def session_log(name, started, length):
-    """ Log a session that was tracked outside of the tracker.
-
-        :param name: The identifier of the session.
-        :type name: str
-
-        :param started: When was the session started (UTC unix timestamp).
-        :type started: int
-
-        :param length: Length of the session in seconds.
-        :param started: int
-    """
-
-    try:
-        af = open_locked(tracker_events_file, 'a')
-    except IOError as e:
-        logger.error("Error while opening events file".format(e))
-    else:
-        with af:
-            session = {
-                'name': name,
-                'started': int(started),
-                'elapsed': int(length)
-            }
-
-            event = get_session_event(session)
-            af.write(json.dumps(event) + "\n")
-        if 'SUDO_USER' in os.environ:
-            chown_path(tracker_events_file)
+# Public imports
+from kano_profile.tracker.tracker import Tracker
+from kano_profile.tracker.tracking_sessions import session_start, session_end, \
+    get_session_file_path, session_log, get_session_unique_id, \
+    get_session_event, CPU_ID, LANGUAGE, OS_VERSION
 
 
 def track_data(name, data):
@@ -306,62 +132,6 @@ def get_action_event(name):
         'language': LANGUAGE,
         'name': name
     }
-
-
-def get_session_event(session):
-    """ Construct the event data structure for a session. """
-
-    return {
-        'type': 'session',
-        'time': session['started'],
-        'timezone_offset': get_utc_offset(),
-        'os_version': OS_VERSION,
-        'cpu_id': CPU_ID,
-        'token': TOKEN,
-        'language': LANGUAGE,
-        'name': session['name'],
-        'length': session['elapsed'],
-        'token-system': session.get('token-system', '')
-    }
-
-
-def get_utc_offset():
-    """ Returns the local UTC offset in seconds.
-
-        :returns: UTC offsed in secconds.
-        :rtype: int
-    """
-
-    is_dst = time.daylight and time.localtime().tm_isdst > 0
-    return -int(time.altzone if is_dst else time.timezone)
-
-
-class Tracker:
-    """Tracker class, used for measuring program run-times,
-    implemented via atexit hooks"""
-
-    def __init__(self):
-        self.path = session_start(get_program_name())
-        atexit.register(self._write_times)
-
-    def _write_times(self):
-        session_end(self.path)
-
-
-# TODO: While it isn't at the moment, this could be useful to have
-#       in the toolset.
-def _get_nearest_previous_monday():
-    """ Returns the timestamp of the nearest past Monday """
-
-    t = time.time()
-    day = 24 * 60 * 60
-    week = 7 * day
-
-    r = (t - (t % week)) - (3 * day)
-    if (t - r) >= week:
-        r += week
-
-    return int(r)
 
 
 def add_runtime_to_app(app, runtime):

--- a/kano_profile/tracker/tracker.py
+++ b/kano_profile/tracker/tracker.py
@@ -1,0 +1,25 @@
+#
+# tracker.py
+#
+# Copyright (C) 2014 - 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Class for handling tracking sessions
+#
+
+import atexit
+
+from kano.utils.processes import get_program_name
+from kano_profile.tracker.tracking_sessions import session_start, session_end
+
+
+class Tracker:
+    """Tracker class, used for measuring program run-times,
+    implemented via atexit hooks"""
+
+    def __init__(self):
+        self.path = session_start(get_program_name())
+        atexit.register(self._write_times)
+
+    def _write_times(self):
+        session_end(self.path)

--- a/kano_profile/tracker/tracker.py
+++ b/kano_profile/tracker/tracker.py
@@ -7,13 +7,14 @@
 # Class for handling tracking sessions
 #
 
+
 import atexit
 
 from kano.utils.processes import get_program_name
 from kano_profile.tracker.tracking_sessions import session_start, session_end
 
 
-class Tracker:
+class Tracker(object):
     """Tracker class, used for measuring program run-times,
     implemented via atexit hooks"""
 

--- a/kano_profile/tracker/tracker_token.py
+++ b/kano_profile/tracker/tracker_token.py
@@ -11,6 +11,7 @@ import os
 import time
 import hashlib
 
+
 from kano.utils.file_operations import ensure_dir, chown_path
 from kano.logging import logger
 from kano_profile.paths import tracker_dir, tracker_token_file, \

--- a/kano_profile/tracker/tracker_token.py
+++ b/kano_profile/tracker/tracker_token.py
@@ -1,0 +1,83 @@
+#
+# tracker_token.py
+#
+# Copyright (C) 2014 - 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Tracking token manipulation
+#
+
+import os
+import time
+import hashlib
+
+from kano.utils.file_operations import ensure_dir, chown_path
+from kano.logging import logger
+from kano_profile.paths import tracker_dir, tracker_token_file, \
+    tracker_events_file
+from kano_profile.tracker.tracking_utils import open_locked
+
+
+def load_token():
+    """
+        Reads the tracker token from the token file. If the file doesn't
+        exists, it regenerates it.
+
+        The token is regenerated on each boot and is inserted into every
+        event to link together events that happened during the same start
+        of the OS.
+
+        :returns: The token.
+        :rtype: str
+    """
+
+    if os.path.exists(tracker_token_file):
+        try:
+            f = open_locked(tracker_token_file, 'r')
+        except IOError as e:
+            logger.error("Error opening tracker token file {}".format(e))
+        else:
+            with f:
+                return f.read().strip()
+    else:
+        return generate_tracker_token()
+
+
+def generate_tracker_token():
+    """
+        Generating the token is a simple md5hash of the current time.
+
+        The token is saved to the `tracker_token_file`.
+
+        :returns: The token.
+        :rtype: str
+    """
+
+    token = hashlib.md5(str(time.time())).hexdigest()
+
+    ensure_dir(tracker_dir)
+    try:
+        f = open_locked(tracker_token_file, 'w')
+    except IOError as e:
+        logger.error(
+            "Error opening tracker token file (generate) {}".format(e))
+    else:
+        with f:
+            f.write(token)
+        if 'SUDO_USER' in os.environ:
+            chown_path(tracker_token_file)
+
+    # Make sure that the events file exist
+    try:
+        f = open(tracker_events_file, 'a')
+    except IOError as e:
+        logger.error("Error opening tracker events file {}".format(e))
+    else:
+        f.close()
+        if 'SUDO_USER' in os.environ:
+            chown_path(tracker_events_file)
+
+    return token
+
+
+TOKEN = load_token()

--- a/kano_profile/tracker/tracking_events.py
+++ b/kano_profile/tracker/tracking_events.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# tracking-events.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# A few predefined tracking events
+
+import json
+
+from kano_profile.tracker import get_action_event, track_data
+from kano_world.connection import request_wrapper, content_type_json
+from kano.utils import get_rpi_model, detect_kano_keyboard, get_partition_info
+
+
+def _hw_info():
+    track_data('hw-info', {
+        'keyboard': 'kano' if detect_kano_keyboard() else 'generic',
+        'model': get_rpi_model(),
+        'partitions': get_partition_info()
+    })
+
+
+def _ping():
+    """
+        The ping event is unauthenticated and is dispatched right away,
+        without passing through the caching layer in the `events` file.
+    """
+    event = json.dumps(get_action_event('ping'))
+    status, err, _ = request_wrapper('post', '/tracking/ping', data=event,
+                                     headers=content_type_json)
+
+    if not status:
+        msg = _("Failed to send the ping event ({})").format(err)
+        raise RuntimeError(msg)
+
+def _low_battery():
+    track_data('battery', {
+        'status': 'low-charge'
+    })
+
+
+def _auto_poweroff():
+    track_data('battery', {
+        'status': 'automatic-poweroff'
+    })
+
+
+event_templates = {
+    'hw-info': _hw_info,
+    'ping': _ping,
+    'low-battery': _low_battery,
+    'auto-poweroff': _auto_poweroff
+}
+
+
+def generate_event(event_name):
+    """
+        Fires off a predefined tracker event (see the tracking_events module).
+
+        :param name: The identifier of the event.
+        :type name: str
+    """
+
+    if event_name in event_templates:
+        event_templates[event_name]()
+    else:
+        raise RuntimeError(_("Unknown event template '{}'.").format(event_name))

--- a/kano_profile/tracker/tracking_session.py
+++ b/kano_profile/tracker/tracking_session.py
@@ -1,0 +1,108 @@
+#
+# tracking_session.py
+#
+# Copyright (C) 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# A class to manage tracking session files
+#
+
+
+import os
+import re
+import json
+
+from kano.logging import logger
+from kano_profile.paths import tracker_dir
+from kano_profile.tracker.tracking_utils import is_pid_running, open_locked
+
+
+class TrackingSession(object):
+    SESSION_FILE_RE = re.compile(r'^(\d+)-(.*).json$')
+
+    def __init__(self, session_file=None, name=None, pid=None):
+        if session_file:
+            self._file = os.path.basename(session_file)
+            self._pid, self._name = self.parse_session_file(self.file)
+        elif name and pid:
+            self._name = name
+            self._pid = int(pid)
+            self._file = self.parse_name_and_pid(self.name, self.pid)
+
+        else:
+            raise TypeError(
+                'TrackingSession requires a file or a name/pid combination'
+            )
+
+    def parse_session_file(self, session_file):
+        matches = TrackingSession.SESSION_FILE_RE.findall(session_file)
+
+        if not matches:
+            return None, None
+
+        match_data = matches[0]
+
+        pid = int(match_data[0])
+        name = match_data[1]
+
+        return pid, name
+
+    def parse_name_and_pid(self, name, pid):
+        return "{}-{}.json".format(pid, name)
+
+    def __repr__(self):
+        return 'Tracking Session [Name: {name}, PID: {pid}]: {is_open}'.format(
+            name=self.name,
+            pid=self.pid,
+            is_open='OPEN' if self.is_open() else 'CLOSED'
+        )
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        return self.file == other.file
+
+    @property
+    def file(self):
+        return self._file
+
+    @property
+    def path(self):
+        return os.path.join(tracker_dir, self.file)
+
+    @property
+    def name(self):
+        return self._name.encode('utf-8')
+
+    @property
+    def pid(self):
+        return self._pid or 0
+
+    def is_open(self):
+        return is_pid_running(self.pid)
+
+    def open(self, mode):
+        try:
+            session_f = open_locked(self.path, mode)
+        except IOError as exc:
+            logger.error(
+                'Error opening the tracking session file "{f}": {err}'
+                .format(f=self.path, err=exc)
+            )
+        else:
+            yield session_f
+
+    def dumps(self):
+        return json.dumps({
+            'name': self.name,
+            'pid': self.pid
+        })
+
+    @staticmethod
+    def loads(session):
+        session_data = json.loads(session.rstrip().lstrip())
+        return TrackingSession(
+            name=session_data.get('name'),
+            pid=session_data.get('pid')
+        )

--- a/kano_profile/tracker/tracking_sessions.py
+++ b/kano_profile/tracker/tracking_sessions.py
@@ -1,0 +1,157 @@
+#
+# tracking_sessions.py
+#
+# Copyright (C) 2014 - 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Functions for tracking app session times
+#
+
+
+import os
+import json
+import time
+from uuid import uuid1, uuid5
+
+from kano.utils.hardware import get_cpu_id
+from kano.utils.file_operations import read_file_contents, chown_path
+from kano.logging import logger
+from kano_profile.tracker.tracker_token import TOKEN
+from kano_profile.paths import tracker_dir, tracker_events_file
+from kano_profile.tracker.tracking_utils import open_locked, get_utc_offset
+
+
+OS_VERSION = str(read_file_contents('/etc/kanux_version'))
+os_variant = read_file_contents('/etc/kanux_version_variant')
+OS_VERSION += '-' + os_variant if os_variant else ''
+CPU_ID = str(get_cpu_id())
+LANGUAGE = (os.getenv('LANG') or '').split('.', 1)[0]
+
+
+def get_session_file_path(name, pid):
+    return "{}/{}-{}.json".format(tracker_dir, pid, name)
+
+
+def get_session_unique_id(name, pid):
+    data = {}
+    tracker_session_file = get_session_file_path(name, pid)
+    try:
+        af = open_locked(tracker_session_file, 'r')
+    except (IOError, OSError) as e:
+        logger.error("Error while opening session file".format(e))
+    else:
+        with af:
+            try:
+                data = json.load(af)
+            except ValueError as e:
+                logger.error("Session file is not a valid JSON")
+
+    return data.get('app_session_id', "")
+
+
+def session_start(name, pid=None):
+    if not pid:
+        pid = os.getpid()
+    pid = int(pid)
+
+    data = {
+        'pid': pid,
+        'name': name,
+        'started': int(time.time()),
+        'elapsed': 0,
+        'app_session_id': str(uuid5(uuid1(), name + str(pid))),
+        'finished': False,
+        'token-system': TOKEN
+    }
+
+    path = get_session_file_path(data['name'], data['pid'])
+
+    try:
+        f = open_locked(path, 'w')
+    except IOError as e:
+        logger.error("Error opening tracker session file {}".format(e))
+    else:
+        with f:
+            json.dump(data, f)
+        if 'SUDO_USER' in os.environ:
+            chown_path(path)
+
+    return path
+
+
+def session_end(session_file):
+    if not os.path.exists(session_file):
+        msg = "Someone removed the tracker file, the runtime of this " \
+              "app will not be logged"
+        logger.warn(msg)
+        return
+
+    try:
+        rf = open_locked(session_file, 'r')
+    except IOError as e:
+        logger.error("Error opening the tracker session file {}".format(e))
+    else:
+        with rf:
+            data = json.load(rf)
+
+            data['elapsed'] = int(time.time()) - data['started']
+            data['finished'] = True
+
+            try:
+                wf = open(session_file, 'w')
+            except IOError as e:
+                logger.error(
+                    "Error opening the tracker session file {}".format(e))
+            else:
+                with wf:
+                    json.dump(data, wf)
+        if 'SUDO_USER' in os.environ:
+            chown_path(session_file)
+
+
+def get_session_event(session):
+    """ Construct the event data structure for a session. """
+
+    return {
+        'type': 'session',
+        'time': session['started'],
+        'timezone_offset': get_utc_offset(),
+        'os_version': OS_VERSION,
+        'cpu_id': CPU_ID,
+        'token': TOKEN,
+        'language': LANGUAGE,
+        'name': session['name'],
+        'length': session['elapsed'],
+        'token-system': session.get('token-system', '')
+    }
+
+
+def session_log(name, started, length):
+    """ Log a session that was tracked outside of the tracker.
+
+        :param name: The identifier of the session.
+        :type name: str
+
+        :param started: When was the session started (UTC unix timestamp).
+        :type started: int
+
+        :param length: Length of the session in seconds.
+        :param started: int
+    """
+
+    try:
+        af = open_locked(tracker_events_file, 'a')
+    except IOError as e:
+        logger.error("Error while opening events file".format(e))
+    else:
+        with af:
+            session = {
+                'name': name,
+                'started': int(started),
+                'elapsed': int(length)
+            }
+
+            event = get_session_event(session)
+            af.write(json.dumps(event) + "\n")
+        if 'SUDO_USER' in os.environ:
+            chown_path(tracker_events_file)

--- a/kano_profile/tracker/tracking_sessions.py
+++ b/kano_profile/tracker/tracking_sessions.py
@@ -38,7 +38,7 @@ def get_session_unique_id(name, pid):
     try:
         af = open_locked(tracker_session_file, 'r')
     except (IOError, OSError) as e:
-        logger.error("Error while opening session file".format(e))
+        logger.error("Error while opening session file: {}".format(e))
     else:
         with af:
             try:
@@ -142,7 +142,7 @@ def session_log(name, started, length):
     try:
         af = open_locked(tracker_events_file, 'a')
     except IOError as e:
-        logger.error("Error while opening events file".format(e))
+        logger.error("Error while opening events file: {}".format(e))
     else:
         with af:
             session = {

--- a/kano_profile/tracker/tracking_sessions.py
+++ b/kano_profile/tracker/tracking_sessions.py
@@ -10,22 +10,51 @@
 
 import os
 import json
+import shutil
 import time
 from uuid import uuid1, uuid5
 
 from kano.utils.hardware import get_cpu_id
-from kano.utils.file_operations import read_file_contents, chown_path
+from kano.utils.file_operations import read_file_contents, chown_path, \
+    ensure_dir
 from kano.logging import logger
 from kano_profile.tracker.tracker_token import TOKEN
-from kano_profile.paths import tracker_dir, tracker_events_file
+from kano_profile.paths import tracker_dir, tracker_events_file, \
+    PAUSED_SESSIONS_FILE
+from kano_profile.tracker.tracking_session import TrackingSession
 from kano_profile.tracker.tracking_utils import open_locked, get_utc_offset
 
 
+CPU_ID = str(get_cpu_id())
+LANGUAGE = (os.getenv('LANG') or '').split('.', 1)[0]
 OS_VERSION = str(read_file_contents('/etc/kanux_version'))
 os_variant = read_file_contents('/etc/kanux_version_variant')
 OS_VERSION += '-' + os_variant if os_variant else ''
-CPU_ID = str(get_cpu_id())
-LANGUAGE = (os.getenv('LANG') or '').split('.', 1)[0]
+
+
+def list_sessions():
+    return [
+        f for f in os.listdir(tracker_dir)
+        if os.path.isfile(os.path.join(tracker_dir, f)) and
+        os.path.join(tracker_dir, f) != PAUSED_SESSIONS_FILE
+    ]
+
+
+def get_open_sessions():
+    open_sessions = []
+
+    for session_file in list_sessions():
+        session = TrackingSession(session_file=session_file)
+
+        if not os.path.isfile(session.path):
+            continue
+
+        if not session.is_open():
+            continue
+
+        open_sessions.append(session)
+
+    return open_sessions
 
 
 def get_session_file_path(name, pid):
@@ -49,10 +78,25 @@ def get_session_unique_id(name, pid):
     return data.get('app_session_id', "")
 
 
-def session_start(name, pid=None):
+def session_start(name, pid=None, ignore_pause=False):
     if not pid:
         pid = os.getpid()
     pid = int(pid)
+
+    if not ignore_pause and is_tracking_paused():
+        session = TrackingSession(name=name, pid=pid)
+        try:
+            paused_sessions_f = open_locked(PAUSED_SESSIONS_FILE, 'a')
+        except IOError as err:
+            logger.error(
+                'Error while opening the paused sessions file: {}'.format(err)
+            )
+        else:
+            paused_sessions_f.write(
+                '{}\n'.format(session.dumps())
+            )
+
+            return session.path
 
     data = {
         'pid': pid,
@@ -107,6 +151,120 @@ def session_end(session_file):
                     json.dump(data, wf)
         if 'SUDO_USER' in os.environ:
             chown_path(session_file)
+
+
+def get_paused_sessions():
+    if not os.path.exists(PAUSED_SESSIONS_FILE):
+        return []
+
+    try:
+        sessions_f = open_locked(PAUSED_SESSIONS_FILE, 'r')
+    except IOError as err:
+        logger.error('Error opening the paused sessions file: {}'.format(err))
+        return []
+    else:
+        with sessions_f:
+            paused_sessions = []
+            for session in sessions_f:
+                if not session:
+                    continue
+
+                paused_sessions.append(
+                    TrackingSession.loads(session)
+                )
+
+            return paused_sessions
+
+
+def is_tracking_paused():
+    return os.path.exists(PAUSED_SESSIONS_FILE)
+
+
+def pause_tracking_session(session):
+    '''
+    Close session and make a note of the session if it is open so that it can
+    be resumed.
+    '''
+
+    if session.is_open():
+        try:
+            sessions_f = open_locked(PAUSED_SESSIONS_FILE, 'a')
+        except IOError as err:
+            logger.error('Error opening the paused sessions file: {}'.format(err))
+        else:
+            with sessions_f:
+                sessions_f.write(
+                    '{}\n'.format(session.dumps())
+                )
+
+    session_end(session.path)
+
+    closed_session = TrackingSession(name=session.name, pid=999999)
+    shutil.move(
+        session.path,
+        '-{}'.format(time.time()).join(
+            os.path.splitext(closed_session.path)
+        )
+    )
+
+
+def unpause_tracking_session(session):
+    '''
+    Restart the session if the process is still alive and remove record of this
+    paused session.
+    '''
+
+    if session.is_open():
+        session_start(session.name, session.pid, ignore_pause=True)
+
+    paused_sessions = get_paused_sessions()
+
+    try:
+        paused_sessions_f = open_locked(PAUSED_SESSIONS_FILE, 'w')
+    except IOError as e:
+        logger.error("Error while opening events file: {}".format(e))
+    else:
+        with paused_sessions_f:
+            for paused_session in paused_sessions:
+                if paused_session != session:
+                    paused_sessions_f.write(
+                        '{}\n'.format(paused_session.dumps())
+                    )
+
+
+def pause_tracking_sessions():
+    '''
+    Loop through all the alive sessions, pausing each one.
+    '''
+
+    open_sessions = get_open_sessions()
+
+    # Mark paused in the event of no sessions
+    if len(open_sessions) == 0:
+        try:
+            paused_sessions_f = open_locked(PAUSED_SESSIONS_FILE, 'a')
+        except IOError as err:
+            logger.error(
+                'Error while opening the paused sessions file: {}'.format(err)
+            )
+        else:
+            with paused_sessions_f:
+                pass
+
+    for session in open_sessions:
+        pause_tracking_session(session)
+
+
+def unpause_tracking_sessions():
+    '''
+    Loop through the paused sessions to resume each one. Finally remove the flag
+    indicating that the system is in a paused state.
+    '''
+
+    for session in get_paused_sessions():
+        unpause_tracking_session(session)
+
+    os.remove(PAUSED_SESSIONS_FILE)
 
 
 def get_session_event(session):

--- a/kano_profile/tracker/tracking_utils.py
+++ b/kano_profile/tracker/tracking_utils.py
@@ -7,6 +7,7 @@
 # Utility functions useful for tracking
 #
 
+import os
 import fcntl
 import time
 
@@ -18,6 +19,20 @@ class open_locked(file):
     def __init__(self, *args, **kwargs):
         super(open_locked, self).__init__(*args, **kwargs)
         fcntl.flock(self, fcntl.LOCK_EX)
+
+
+def is_pid_running(pid):
+    '''
+    Sending a signal 0 to a running process will do nothing. Sending it to a
+    dead process will throw an OSError exception
+    '''
+
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
 
 
 # TODO: While it isn't at the moment, this could be useful to have

--- a/kano_profile/tracker/tracking_utils.py
+++ b/kano_profile/tracker/tracking_utils.py
@@ -1,0 +1,47 @@
+#
+# tracking_utils.py
+#
+# Copyright (C) 2014 - 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Utility functions useful for tracking
+#
+
+import fcntl
+import time
+
+
+class open_locked(file):
+    """ A version of open with an exclusive lock to be used within
+        controlled execution statements.
+    """
+    def __init__(self, *args, **kwargs):
+        super(open_locked, self).__init__(*args, **kwargs)
+        fcntl.flock(self, fcntl.LOCK_EX)
+
+
+# TODO: While it isn't at the moment, this could be useful to have
+#       in the toolset.
+def _get_nearest_previous_monday():
+    """ Returns the timestamp of the nearest past Monday """
+
+    t = time.time()
+    day = 24 * 60 * 60
+    week = 7 * day
+
+    r = (t - (t % week)) - (3 * day)
+    if (t - r) >= week:
+        r += week
+
+    return int(r)
+
+
+def get_utc_offset():
+    """ Returns the local UTC offset in seconds.
+
+        :returns: UTC offsed in secconds.
+        :rtype: int
+    """
+
+    is_dst = time.daylight and time.localtime().tm_isdst > 0
+    return -int(time.altzone if is_dst else time.timezone)

--- a/kano_profile/tracker/tracking_utils.py
+++ b/kano_profile/tracker/tracking_utils.py
@@ -22,7 +22,7 @@ class open_locked(file):
 
 # TODO: While it isn't at the moment, this could be useful to have
 #       in the toolset.
-def _get_nearest_previous_monday():
+def get_nearest_previous_monday():
     """ Returns the timestamp of the nearest past Monday """
 
     t = time.time()

--- a/kano_profile/tracking_events.py
+++ b/kano_profile/tracking_events.py
@@ -1,69 +1,10 @@
-#!/usr/bin/env python
-
 # tracking-events.py
 #
-# Copyright (C) 2015 Kano Computing Ltd.
+# Copyright (C) 2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # A few predefined tracking events
+# Just imports from the moved submodule but used to prevent breaking the legacy
+# interface
 
-import json
-
-from .tracker import get_action_event, track_data
-from kano_world.connection import request_wrapper, content_type_json
-from kano.utils import get_rpi_model, detect_kano_keyboard, get_partition_info
-
-
-def _hw_info():
-    track_data('hw-info', {
-        'keyboard': 'kano' if detect_kano_keyboard() else 'generic',
-        'model': get_rpi_model(),
-        'partitions': get_partition_info()
-    })
-
-
-def _ping():
-    """
-        The ping event is unauthenticated and is dispatched right away,
-        without passing through the caching layer in the `events` file.
-    """
-    event = json.dumps(get_action_event('ping'))
-    status, err, _ = request_wrapper('post', '/tracking/ping', data=event,
-                                     headers=content_type_json)
-
-    if not status:
-        msg = _("Failed to send the ping event ({})").format(err)
-        raise RuntimeError(msg)
-
-def _low_battery():
-    track_data('battery', {
-        'status': 'low-charge'
-    })
-
-
-def _auto_poweroff():
-    track_data('battery', {
-        'status': 'automatic-poweroff'
-    })
-
-
-event_templates = {
-    'hw-info': _hw_info,
-    'ping': _ping,
-    'low-battery': _low_battery,
-    'auto-poweroff': _auto_poweroff
-}
-
-
-def generate_event(event_name):
-    """
-        Fires off a predefined tracker event (see the tracking_events module).
-
-        :param name: The identifier of the event.
-        :type name: str
-    """
-
-    if event_name in event_templates:
-        event_templates[event_name]()
-    else:
-        raise RuntimeError(_("Unknown event template '{}'.").format(event_name))
+from kano_profile.tracker.tracking_events import generate_event

--- a/tests/profile/tracking/test_tracker_token.py
+++ b/tests/profile/tracking/test_tracker_token.py
@@ -1,0 +1,62 @@
+import os
+import time
+import hashlib
+import re
+
+from kano_profile.paths import tracker_token_file
+from kano_profile.tracker.tracker_token import load_token, TOKEN, \
+    generate_tracker_token
+
+
+TOKEN_REGEX = re.compile(r'[0-9a-f]{32}')
+
+
+def validate_token(token):
+    assert len(token) == 32
+    assert TOKEN_REGEX.match(token)
+
+
+'''
+TODO: Try to do something smarter here as TOKEN is created on import which may
+      be invalidated with the manipulations from the other tests
+'''
+def test_token_var():
+    token = load_token()
+
+    assert token == TOKEN
+    validate_token(token)
+
+
+def test_token_cache_load():
+    test_token = hashlib.md5(str(time.time())).hexdigest()
+
+    with open(tracker_token_file, 'w') as token_f:
+        token_f.write(test_token)
+
+    assert test_token == load_token()
+
+
+def test_token_regen_load():
+    if os.path.exists(tracker_token_file):
+        os.remove(tracker_token_file)
+
+    created_token = load_token()
+
+    with open(tracker_token_file, 'r') as token_f:
+        expected_token = token_f.read()
+
+    assert created_token == expected_token
+    validate_token(created_token)
+
+
+def test_token_gen():
+    if os.path.exists(tracker_token_file):
+        os.remove(tracker_token_file)
+
+    created_token = generate_tracker_token()
+
+    with open(tracker_token_file, 'r') as token_f:
+        expected_token = token_f.read()
+
+    assert created_token == expected_token
+    validate_token(created_token)

--- a/tests/profile/tracking/test_tracking_events.py
+++ b/tests/profile/tracking/test_tracking_events.py
@@ -1,0 +1,92 @@
+import os
+import json
+import time
+import pytest
+
+# import fcntl
+# import mock
+# from pyfakefs.pytest_plugin import fs as fake_fs
+# from pyfakefs.fake_filesystem import FakeFile
+
+from kano_profile.paths import tracker_events_file
+import kano_profile.tracker.tracking_events as tracking_events
+from kano_profile.tracker.tracker_token import TOKEN
+# from kano_profile.tracking_events import generate_event
+
+'''
+def test_generate_low_battery_event(fs, monkeypatch):
+    # def mock_fcntl_flock(f, flag):
+    #     # f.open(flag)
+    #     pass
+
+    # monkeypatch.setattr(fcntl, 'flock', mock_fcntl_flock)
+
+    print('test', file)
+    print(fs)
+    print(monkeypatch)
+    # fake_fs(fs)
+
+    import kano_profile.tracker.tracking_events as tracking_events
+    from kano_profile.tracker.tracking_utils import open_locked
+
+    with mock.patch.object(open_locked, '__bases__', (FakeFile,)):
+        patcher.is_local = True
+        print('patching', open_locked, open_locked.__bases__)
+        tracking_events.generate_event('low-battery')
+
+    assert os.path.exists(tracker_events_file)
+
+    events = []
+
+    with open(tracker_events_file, 'r') as events_f:
+        events = json.loads(events_f.readline())
+
+    assert len(events) > 0
+'''
+
+@pytest.mark.parametrize('event_name, event_type, event_data', [
+    ('low-battery', 'battery', '{"status": "low-charge"}'),
+    ('auto-poweroff', 'battery', '{"status": "automatic-poweroff"}')
+    ])
+def test_generate_low_battery_event(event_name, event_type, event_data):
+    if os.path.exists(tracker_events_file):
+        os.remove(tracker_events_file)
+
+    tracking_events.generate_event(event_name)
+
+    assert os.path.exists(tracker_events_file)
+
+    events = []
+
+    with open(tracker_events_file, 'r') as events_f:
+        events.append(json.loads(events_f.readline()))
+
+    assert len(events) == 1
+
+    event = events[0]
+
+    expected_keys = [
+        'name',
+        'language',
+        'type',
+        'timezone_offset',
+        'cpu_id',
+        'os_version',
+        'token',
+        'time',
+        'data'
+    ]
+
+    for key in expected_keys:
+        assert key in event
+
+    assert event['name'] == event_type
+    # language: en_GB,
+    assert event['type'] == 'data'
+    # timezone_offset: 3600,
+    # cpu_id: None,
+    # os_version: None,
+    assert event['token'] == TOKEN
+    # Allow some margin for time passing
+    assert abs(time.time() - event['time']) < 5
+    assert event['data'] == json.loads(event_data)

--- a/tests/profile/tracking/test_tracking_imports.py
+++ b/tests/profile/tracking/test_tracking_imports.py
@@ -1,0 +1,42 @@
+import pytest
+
+import kano_profile.tracker as tracker
+import kano_profile.tracking_events as tracking_events
+
+
+@pytest.mark.parametrize('module_export', [
+    'open_locked',
+    'load_token',
+    'generate_tracker_token',
+    'OS_VERSION',
+    'OS_VERSION',
+    'CPU_ID',
+    'TOKEN',
+    'LANGUAGE',
+    'get_session_file_path',
+    'get_session_unique_id',
+    'session_start',
+    'session_end',
+    'session_log',
+    'track_data',
+    'track_action',
+    'track_subprocess',
+    'get_action_event',
+    'get_session_event',
+    'get_utc_offset',
+    'Tracker',
+    'add_runtime_to_app',
+    'save_hardware_info',
+    'save_kano_version',
+    'get_tracker_events',
+    'clear_tracker_events',
+    ])
+def test_tracker_module_import(module_export):
+    getattr(tracker, module_export)
+
+
+@pytest.mark.parametrize('module_export', [
+    'generate_event',
+    ])
+def test_tracking_events_module_import(module_export):
+    getattr(tracking_events, module_export)

--- a/tests/profile/tracking/test_tracking_session.py
+++ b/tests/profile/tracking/test_tracking_session.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+
+from kano_profile.paths import tracker_dir
+from kano_profile.tracker.tracking_session import TrackingSession
+
+
+TEST_DATA = [
+    {
+        'file': '1242-test-file-1.json',
+        'path': os.path.join(tracker_dir, '1242-test-file-1.json'),
+        'pid': 1242,
+        'name': 'test-file-1'
+    },
+]
+
+
+@pytest.mark.parametrize('test_data', TEST_DATA)
+def test_file_init(test_data):
+    session_file = test_data['file']
+    session_path = test_data['path']
+    session_pid = test_data['pid']
+    session_name = test_data['name']
+
+    session = TrackingSession(session_file=session_file)
+
+    assert session.file == session_file
+    assert session.path == session_path
+    assert session.pid == session_pid
+    assert session.name == session_name
+
+
+@pytest.mark.parametrize('test_data', TEST_DATA)
+def test_pid_name_init(test_data):
+    session_file = test_data['file']
+    session_path = test_data['path']
+    session_pid = test_data['pid']
+    session_name = test_data['name']
+
+    session = TrackingSession(pid=session_pid, name=session_name)
+
+    assert session.file == session_file
+    assert session.path == session_path
+    assert session.pid == session_pid
+    assert session.name == session_name

--- a/tests/profile/tracking/test_tracking_sessions.py
+++ b/tests/profile/tracking/test_tracking_sessions.py
@@ -1,0 +1,280 @@
+import os
+import json
+import pytest
+from uuid import uuid1, uuid5
+
+import kano_profile.tracker.tracking_sessions as tracking_sessions
+from kano_profile.tracker.tracking_session import TrackingSession
+from kano_profile.paths import tracker_dir, PAUSED_SESSIONS_FILE, \
+    tracker_events_file
+
+
+'''
+{"name": "kano-dashboard", "started": 1459774858, "pid": 9999, "elapsed": 7, "finished": true, "app_session_id": "d1ea40d1-ddc8-5a62-97a2-980b71a9bc19"}
+'''
+
+def format_session(name, started, pid, elapsed, finished):
+    return {
+        "name": name,
+        "started": started,
+        "pid": pid,
+        "elapsed": elapsed,
+        "finished": finished,
+        "app_session_id": str(uuid5(uuid1(), '{}{}'.format(name, pid)))
+    }
+
+
+def setup_session_fixtures(directory, sessions):
+    for session_f in os.listdir(directory):
+        session_path = os.path.join(directory, session_f)
+        if os.path.isfile(session_path):
+            os.remove(session_path)
+
+    for session in sessions:
+        session_obj = TrackingSession(
+            name=session['name'],
+            pid=session['pid']
+        )
+        session_path = os.path.join(directory, session_obj.file)
+
+        with open(session_path, 'w') as session_f:
+            json.dump(session, session_f)
+
+
+def setup_sessions_dir(sessions):
+    setup_session_fixtures(tracker_dir, sessions)
+
+def setup_paused_sessions_file(sessions):
+    if sessions == None:
+        if os.path.exists(PAUSED_SESSIONS_FILE):
+            os.remove(PAUSED_SESSIONS_FILE)
+
+        return
+
+    with open(PAUSED_SESSIONS_FILE, 'w') as sessions_f:
+        for session in sessions:
+            sessions_f.write(
+                '{}\n'.format(json.dumps({
+                    'name': session['name'],
+                    'pid': session['pid']
+                }))
+            )
+
+
+SAMPLE_SESSIONS = [
+    format_session('test-1', 12345678, 1234, 60, True),
+    format_session('test-2', 22345678, 1234, 32, True),
+    format_session('test-3', 32345678, 1234, 288, True),
+    format_session('test-4', 42345678, 1234, 119, False),
+    format_session('test-5', 52345678, 1234, 3, False),
+]
+
+
+def test_list_sessions():
+    setup_sessions_dir(SAMPLE_SESSIONS)
+    setup_paused_sessions_file(None)
+
+    listed_sessions = tracking_sessions.list_sessions()
+
+    assert len(listed_sessions) == len(SAMPLE_SESSIONS)
+
+    for session in SAMPLE_SESSIONS:
+        session_path = tracking_sessions.get_session_file_path(
+            session['name'],
+            session['pid']
+        )
+        assert os.path.basename(session_path) in listed_sessions
+
+
+def test_get_open_sessions():
+    sample_sessions = SAMPLE_SESSIONS[:]
+    open_session = format_session(
+        'active-session', 987654321, os.getpid(), 55, True
+    )
+    sample_sessions.append(open_session)
+    setup_sessions_dir(sample_sessions)
+    setup_paused_sessions_file(None)
+
+    listed_sessions = tracking_sessions.get_open_sessions()
+
+    for session in listed_sessions:
+        assert session.is_open()
+
+    assert len(listed_sessions) == 1
+
+    listed_session = listed_sessions[0]
+
+    open_session_path = tracking_sessions.get_session_file_path(
+        open_session['name'],
+        open_session['pid']
+    )
+
+    assert os.path.basename(open_session_path) == listed_session.file
+    assert os.path.abspath(open_session_path) == listed_session.path
+    assert open_session['name'] == listed_session.name
+    assert open_session['pid'] == listed_session.pid
+
+
+@pytest.mark.parametrize('name, pid, expected', [
+    ('test-1', 1234, os.path.join(tracker_dir, '1234-test-1.json')),
+    ('test-2', 5830, os.path.join(tracker_dir, '5830-test-2.json')),
+])
+def test_get_session_file_path(name, pid, expected):
+    session_file_path = os.path.abspath(
+        tracking_sessions.get_session_file_path(name, pid)
+    )
+    assert session_file_path == expected
+
+
+# @pytest.mark.parametrize('name, pid', TEST_DATA)
+# def test_get_session_unique_id(name, pid):
+#     pass
+
+
+def test_session_start_with_pid():
+    setup_sessions_dir([])
+    setup_paused_sessions_file(None)
+
+    test_session = TrackingSession(name='test', pid=1234)
+    session_path = tracking_sessions.session_start(
+        test_session.name, test_session.pid
+    )
+
+    assert os.path.abspath(session_path) == test_session.path
+
+    with open(test_session.path, 'r') as test_session_f:
+        session_data = json.load(test_session_f)
+
+    assert test_session.name == session_data['name']
+    assert test_session.pid == session_data['pid']
+
+
+def test_session_start_no_pid():
+    setup_sessions_dir([])
+    setup_paused_sessions_file(None)
+
+    test_session = TrackingSession(name='test', pid=os.getpid())
+    session_path = tracking_sessions.session_start(
+        test_session.name
+    )
+
+    assert os.path.abspath(session_path) == test_session.path
+
+    with open(test_session.path, 'r') as test_session_f:
+        session_data = json.load(test_session_f)
+
+    assert test_session.name == session_data['name']
+    assert test_session.pid == session_data['pid']
+
+
+def test_session_end():
+    pass
+
+
+def test_get_paused_sessions():
+    setup_paused_sessions_file(SAMPLE_SESSIONS)
+
+    paused_sessions = tracking_sessions.get_paused_sessions()
+
+    assert len(paused_sessions) == len(SAMPLE_SESSIONS)
+
+    for session in SAMPLE_SESSIONS:
+        session_obj = TrackingSession(name=session['name'], pid=session['pid'])
+        assert session_obj in paused_sessions
+
+
+# @pytest.mark.parametrize('session', TEST_DATA)
+# def test_pause_tracking_session(session):
+#     pass
+#
+#
+# @pytest.mark.parametrize('session', TEST_DATA)
+# def test_unpause_tracking_session(session):
+#     pass
+
+
+@pytest.mark.parametrize(
+    'unpaused_sessions, paused_sessions, expected',
+    [
+        (SAMPLE_SESSIONS, [], True),
+        (SAMPLE_SESSIONS, None, False),
+        ([], SAMPLE_SESSIONS, True),
+    ]
+)
+def test_is_tracking_paused(unpaused_sessions, paused_sessions, expected):
+    setup_sessions_dir(unpaused_sessions)
+    setup_paused_sessions_file(paused_sessions)
+
+    assert tracking_sessions.is_tracking_paused() == expected
+
+
+def test_pause_tracking_sessions():
+    sample_sessions = SAMPLE_SESSIONS[:]
+    open_session = format_session(
+        'active-session', 987654321, os.getpid(), 55, False
+    )
+    open_session_obj = TrackingSession(
+        name=open_session['name'], pid=open_session['pid']
+    )
+    sample_sessions.append(open_session)
+    setup_sessions_dir(sample_sessions)
+    setup_paused_sessions_file(None)
+
+    assert tracking_sessions.get_open_sessions() == [open_session_obj]
+    assert tracking_sessions.get_paused_sessions() == []
+
+    tracking_sessions.pause_tracking_sessions()
+
+    assert tracking_sessions.get_open_sessions() == []
+    assert tracking_sessions.get_paused_sessions() == [open_session_obj]
+
+    with open(PAUSED_SESSIONS_FILE, 'r') as paused_sessions_f:
+        sessions = [
+            line for line in paused_sessions_f
+            if line
+        ]
+        assert len(sessions) == 1
+        assert TrackingSession.loads(sessions[0]) == open_session_obj
+
+
+def test_unpause_tracking_sessions():
+    sample_sessions = SAMPLE_SESSIONS[:]
+    open_session = format_session(
+        'active-session', 987654321, os.getpid(), 55, False
+    )
+    open_session_obj = TrackingSession(
+        name=open_session['name'], pid=open_session['pid']
+    )
+    sample_sessions.append(open_session)
+    setup_sessions_dir([])
+    setup_paused_sessions_file(sample_sessions)
+
+    tracking_sessions.unpause_tracking_sessions()
+
+    assert tracking_sessions.get_open_sessions() == [open_session_obj]
+    assert tracking_sessions.get_paused_sessions() == []
+
+    for path, dummy_dirs, files in os.walk(tracker_dir):
+        if path == tracker_dir:
+            assert len(files) == 1
+            assert files[0] == open_session_obj.file
+
+
+@pytest.mark.parametrize(
+    'name, started, length',
+    [
+        ('test-1', 123456, 1337),
+    ]
+)
+def test_session_log(name, started, length):
+    if os.path.exists(tracker_events_file):
+        os.remove(tracker_events_file)
+
+    tracking_sessions.session_log(name, started, length)
+
+    with open(tracker_events_file, 'r') as events_f:
+        events_data = json.load(events_f)
+
+    assert events_data['name'] == name
+    assert events_data['time'] == started
+    assert events_data['length'] == length


### PR DESCRIPTION
Add ability to pause tracking sessions and resume them to allow app
times to account for breaks in the user's activity.

